### PR TITLE
Feat/12 브랜드 팬덤페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/brandol/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/brandol/apiPayload/code/status/ErrorStatus.java
@@ -16,6 +16,9 @@ public enum ErrorStatus implements BaseCode {
     //브랜드
     _NOT_EXIST_BRAND(HttpStatus.BAD_REQUEST,"BRAND400","존재하지 않는 브랜드입니다."),
 
+    //멤버 브랜드 리스트
+    _ALREADY_EXIST_MEMBERM_BRAND_LIST(HttpStatus.BAD_REQUEST,"MEMBER-BRAND-LIST400","이미 구독중인 브랜드 입니다."),
+
     //메인 배너
     _CANNOT_LOAD_MAIN_BANNER(HttpStatus.NOT_FOUND,"MAIN-BANNER404","메인배너 조회에 실패했습니다."),
     _CANNOT_LOAD_BRANDOL_MAIN_BANNER(HttpStatus.NOT_FOUND,"MAIN-BANNER4004","시스템 기본값인 BRANDOL이 존재하지 않습니다."),
@@ -28,6 +31,9 @@ public enum ErrorStatus implements BaseCode {
 
     //유저
     _NOT_EXIST_MEMBER(HttpStatus.BAD_REQUEST,"MEMBER400","존재하지 않는 회원입니다."),
+
+    //DB
+    _DUPLICATE_DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"DATABASE500","DB에서 중복 데이터가 조회됨"),
 
     //파일
     _FILE_NAME_ERROR(HttpStatus.BAD_REQUEST,"FILE400","잘못된 파일 형식명입니다.");

--- a/src/main/java/com/brandol/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/brandol/apiPayload/code/status/ErrorStatus.java
@@ -17,7 +17,8 @@ public enum ErrorStatus implements BaseCode {
     _NOT_EXIST_BRAND(HttpStatus.BAD_REQUEST,"BRAND400","존재하지 않는 브랜드입니다."),
 
     //멤버 브랜드 리스트
-    _ALREADY_EXIST_MEMBERM_BRAND_LIST(HttpStatus.BAD_REQUEST,"MEMBER-BRAND-LIST400","이미 구독중인 브랜드 입니다."),
+    _ALREADY_EXIST_MEMBER_BRAND_LIST(HttpStatus.BAD_REQUEST,"MEMBER-BRAND-LIST400","이미 구독중인 브랜드 입니다."),
+    _NOT_EXIST_MEMBER_BRAND_LIST(HttpStatus.BAD_REQUEST,"MEMBER-BRAND-LIST404","멤버-브랜드-리스트 조회 실패"),
 
     //메인 배너
     _CANNOT_LOAD_MAIN_BANNER(HttpStatus.NOT_FOUND,"MAIN-BANNER404","메인배너 조회에 실패했습니다."),

--- a/src/main/java/com/brandol/controller/BrandController.java
+++ b/src/main/java/com/brandol/controller/BrandController.java
@@ -15,23 +15,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
-@Validated //PathVariable Valid 필수 설정
 public class BrandController {
 
     private final BrandService brandService;
 
+
     @Operation(summary = "브랜드 등록",description ="브랜돌 서비스에 브랜드를 신규 등록하는 함수" )
-    @Parameters({
-            @Parameter(name="name",description = "브랜드 이름"),
-            @Parameter(name = "description" , description = "브랜드 소개"),
-            @Parameter(name = "profileImage", description = "프로필 이미지 파일"),
-            @Parameter(name = "backgroundImage",description = "배경 이미지 파일")
-    })
     @PostMapping(value = "/brands/new",consumes = "multipart/form-data") // 브랜드 신규 등록 함수
     private ApiResponse<Brand> addNewBrand(@ModelAttribute AddBrandRequest request){
-        System.out.println("************************ -1-");
         Brand brand = brandService.createBrand(request);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(), brand);
     }
@@ -40,8 +35,7 @@ public class BrandController {
     @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @Parameter(name = "brandId",description = "조회 대상 브랜드의 ID")
     @GetMapping(value = "/brands/{brandId}/header")
-    public ApiResponse<BrandCommonHeaderResponse> showBrandHeader(@ExistBrand @PathVariable("brandId")Long brandId, @RequestParam("memberId")Long memberId){
-
+    public ApiResponse<BrandCommonHeaderResponse> showBrandHeader(@PathVariable("brandId")Long brandId, @RequestParam("memberId")Long memberId){
         BrandCommonHeaderResponse brandCommonHeaderResponse = brandService.makeBrandCommonHeader(brandId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(),SuccessStatus._OK.getMessage(), brandCommonHeaderResponse);
     }

--- a/src/main/java/com/brandol/controller/BrandController.java
+++ b/src/main/java/com/brandol/controller/BrandController.java
@@ -4,18 +4,22 @@ import com.brandol.apiPayload.ApiResponse;
 import com.brandol.apiPayload.code.status.SuccessStatus;
 import com.brandol.domain.Brand;
 import com.brandol.dto.request.AddBrandRequest;
+import com.brandol.dto.response.BrandCommonHeaderResponse;
+import com.brandol.dto.response.BrandFandomBodyResponse;
 import com.brandol.service.BrandService;
+import com.brandol.validation.annotation.ExistBrand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.models.media.MediaType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
+@Validated //PathVariable Valid 필수 설정
 public class BrandController {
+
     private final BrandService brandService;
 
     @Operation(summary = "브랜드 등록",description ="브랜돌 서비스에 브랜드를 신규 등록하는 함수" )
@@ -27,7 +31,26 @@ public class BrandController {
     })
     @PostMapping(value = "/brands/new",consumes = "multipart/form-data") // 브랜드 신규 등록 함수
     private ApiResponse<Brand> addNewBrand(@ModelAttribute AddBrandRequest request){
+        System.out.println("************************ -1-");
         Brand brand = brandService.createBrand(request);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(), brand);
     }
+
+    @Operation(summary = "브랜드 공통 헤더 조회",description ="브랜드 프로필,배경이미지, 구독자 수등 브랜드 상세정보 헤더를 조회" )
+    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
+    @Parameter(name = "brandId",description = "조회 대상 브랜드의 ID")
+    @GetMapping(value = "/brands/{brandId}/header")
+    public ApiResponse<BrandCommonHeaderResponse> showBrandHeader(@ExistBrand @PathVariable("brandId")Long brandId, @RequestParam("memberId")Long memberId){
+
+        BrandCommonHeaderResponse brandCommonHeaderResponse = brandService.makeBrandCommonHeader(brandId,memberId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(),SuccessStatus._OK.getMessage(), brandCommonHeaderResponse);
+    }
+    @Operation(summary = "브랜드 팬덤 조회",description ="브랜드 팬덤에 종속된 브랜드 컬처, 브랜드 공지사항 최신 2건을 조회" )
+    @Parameter(name = "brandId",description = "조회 대상 브랜드의 ID")
+    @GetMapping(value = "/brands/{brandId}/fandom")
+    public ApiResponse<BrandFandomBodyResponse> showBrandBody(@ExistBrand @PathVariable("brandId")Long brandId) {
+        BrandFandomBodyResponse brandFandomBody = brandService.makeBrandFandomBody(brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), brandFandomBody);
+    }
+
 }

--- a/src/main/java/com/brandol/controller/MemberBrandController.java
+++ b/src/main/java/com/brandol/controller/MemberBrandController.java
@@ -15,10 +15,12 @@ import com.brandol.service.BrandService;
 import com.brandol.service.ContentsService;
 import com.brandol.service.MemberBrandService;
 import com.brandol.service.MemberService;
+import com.brandol.validation.annotation.ExistBrand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -28,6 +30,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
+@Validated
 public class MemberBrandController {
 
     private final MemberService memberService;
@@ -45,7 +48,7 @@ public class MemberBrandController {
     @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @Parameter(name = "brandId",description = "삭제 대상 브랜드의 ID")
     @PostMapping("users/my-board-list/unsubscribe/{brandId}")
-    public ApiResponse<String> MemberBrandListStatusToUnsubscribed(@RequestParam Long memberId,@PathVariable("brandId")Long brandId){
+    public ApiResponse<String> MemberBrandListStatusToUnsubscribed(@RequestParam Long memberId,@ExistBrand @PathVariable("brandId")Long brandId){
         MemberBrandList memberBrandList = memberBrandService.MemberBrandListStatusToUnsubscribed(memberId,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._CREATED.getMessage(), "처리 성공");
     }

--- a/src/main/java/com/brandol/controller/MemberBrandController.java
+++ b/src/main/java/com/brandol/controller/MemberBrandController.java
@@ -48,7 +48,7 @@ public class MemberBrandController {
     @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @Parameter(name = "brandId",description = "삭제 대상 브랜드의 ID")
     @PostMapping("users/my-board-list/unsubscribe/{brandId}")
-    public ApiResponse<String> MemberBrandListStatusToUnsubscribed(@RequestParam Long memberId,@ExistBrand @PathVariable("brandId")Long brandId){
+    public ApiResponse<String> MemberBrandListStatusToUnsubscribed(@RequestParam Long memberId,@PathVariable("brandId")Long brandId){
         MemberBrandList memberBrandList = memberBrandService.MemberBrandListStatusToUnsubscribed(memberId,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._CREATED.getMessage(), "처리 성공");
     }

--- a/src/main/java/com/brandol/domain/Fandom.java
+++ b/src/main/java/com/brandol/domain/Fandom.java
@@ -37,4 +37,8 @@ public class Fandom extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "brand_id",nullable = false)
     private Brand brand;
+
+    public void AddBrand(Brand brand){
+        this.brand=brand;
+    }
 }

--- a/src/main/java/com/brandol/dto/request/AddBrandRequest.java
+++ b/src/main/java/com/brandol/dto/request/AddBrandRequest.java
@@ -1,6 +1,7 @@
 package com.brandol.dto.request;
 
 import com.brandol.domain.Brand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,13 +15,16 @@ import javax.validation.constraints.NotNull;
 @Setter
 @Valid
 public class AddBrandRequest{ // 브랜드 신규등록 DTO
-
+    @Schema(description = "등록할 브랜드의 이름")
     @NotNull
     private String name;
+    @Schema(description = "등록할 브랜드의 소개")
     @NotNull
     private String description;
+    @Schema(description = "등록할 브랜드의 프로필 이미지")
     @NotNull
     private MultipartFile profileImage;
+    @Schema(description = "등록할 브랜드의 배경 이미지")
     @NotNull
     private MultipartFile backgroundImage;
 

--- a/src/main/java/com/brandol/dto/request/AddBrandRequest.java
+++ b/src/main/java/com/brandol/dto/request/AddBrandRequest.java
@@ -4,14 +4,12 @@ import com.brandol.domain.Brand;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-
-@Getter
-@Setter //멀티파트 파일 처리시 필수
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class AddBrandRequest { // 브랜드 신규등록 DTO
+@Getter
+@Setter
+public class AddBrandRequest{ // 브랜드 신규등록 DTO
 
    private String name;
 

--- a/src/main/java/com/brandol/dto/request/AddBrandRequest.java
+++ b/src/main/java/com/brandol/dto/request/AddBrandRequest.java
@@ -4,20 +4,25 @@ import com.brandol.domain.Brand;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
 @Setter
+@Valid
 public class AddBrandRequest{ // 브랜드 신규등록 DTO
 
-   private String name;
-
-   private String description;
-
-   private MultipartFile profileImage;
-
-   private MultipartFile backgroundImage;
+    @NotNull
+    private String name;
+    @NotNull
+    private String description;
+    @NotNull
+    private MultipartFile profileImage;
+    @NotNull
+    private MultipartFile backgroundImage;
 
     public static Brand toEntity(AddBrandRequest request){
 

--- a/src/main/java/com/brandol/dto/response/BrandCommonHeaderResponse.java
+++ b/src/main/java/com/brandol/dto/response/BrandCommonHeaderResponse.java
@@ -1,0 +1,23 @@
+package com.brandol.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrandCommonHeaderResponse {
+    private Map<String,Object> brandHeader = new HashMap<>(); //브랜드 페이지 헤더
+    public static BrandCommonHeaderResponse makeBrandHeader(Map<String,Object>brandHeader){
+
+        return BrandCommonHeaderResponse.builder()
+                .brandHeader(brandHeader)
+                .build();
+    }
+}

--- a/src/main/java/com/brandol/dto/response/BrandFandomBodyResponse.java
+++ b/src/main/java/com/brandol/dto/response/BrandFandomBodyResponse.java
@@ -1,0 +1,22 @@
+package com.brandol.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrandFandomBodyResponse { // 브랜드 페이지 바디
+    private Map<String,Object> brandFandomBody = new HashMap<>();
+    public static BrandFandomBodyResponse makeBrandBody(Map<String,Object>brandFandom){
+        return BrandFandomBodyResponse.builder()
+                .brandFandomBody(brandFandom)
+                .build();
+    }
+}

--- a/src/main/java/com/brandol/dto/subDto/BrandFandomBody.java
+++ b/src/main/java/com/brandol/dto/subDto/BrandFandomBody.java
@@ -1,0 +1,62 @@
+package com.brandol.dto.subDto;
+
+import com.brandol.domain.Fandom;
+import com.brandol.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrandFandomBody {
+    private List<Fandom> fandomList = new ArrayList<>();
+    private Member adminMember;
+
+    public static Map<String,Object> createFandomBody(List<Fandom>fandomCultureList,List<Fandom>fandomNoticeList,Member adminMember){
+        Map<String,Object> result = new LinkedHashMap<>();
+
+        //팬덤컬처
+        Map<String,Object> fandomCulture = new LinkedHashMap<>();
+        int fandomCultureLen = fandomCultureList.size();
+        for(int i=0;i<fandomCultureLen;i++){
+            Map<String,Object> fandomCultureData = new LinkedHashMap<>();
+            String key = "article" + i;
+            fandomCultureData.put("writer-id",adminMember.getId());
+            fandomCultureData.put("writer-name",adminMember.getName());
+            fandomCultureData.put("writer-profile", adminMember.getAvatar());
+            fandomCultureData.put("title",fandomCultureList.get(i).getTitle());
+            fandomCultureData.put("content",fandomCultureList.get(i).getContent());
+            fandomCultureData.put("like-count",fandomCultureList.get(i).getLikes());
+            fandomCultureData.put("comment-count",fandomCultureList.get(i).getComments());
+            fandomCultureData.put("written-date",fandomCultureList.get(i).getCreatedAt());
+            fandomCulture.put(key,fandomCultureData);
+        }
+
+        //팬덤 노티스
+        Map<String,Object> fandomNotice = new LinkedHashMap<>();
+        int fandomNoticeLen = fandomNoticeList.size();
+        for(int i=0;i<fandomNoticeLen;i++){
+            Map<String,Object>fandomNoticeData = new LinkedHashMap<>();
+            String key = "notice"+i;
+            fandomNoticeData.put("writer-id",adminMember.getId());
+            fandomNoticeData.put("writer",adminMember.getName());
+            fandomNoticeData.put("writer-profile",adminMember.getAvatar());
+            fandomNoticeData.put("title",fandomCultureList.get(i).getTitle());
+            fandomNoticeData.put("content",fandomCultureList.get(i).getContent());
+            fandomNoticeData.put("like-count",fandomCultureList.get(i).getLikes());
+            fandomNoticeData.put("comment-count",fandomCultureList.get(i).getComments());
+            fandomNoticeData.put("written-date",fandomNoticeList.get(i).getCreatedAt());
+            fandomNotice.put(key,fandomNoticeData);
+        }
+
+        result.put("fandom-culture",fandomCulture); //팬덤컬처 탑재
+        result.put("fandom-notice",fandomNotice); // 팬검 노티스 탑재
+
+        return result;
+    }
+}

--- a/src/main/java/com/brandol/dto/subDto/BrandHeader.java
+++ b/src/main/java/com/brandol/dto/subDto/BrandHeader.java
@@ -1,0 +1,52 @@
+package com.brandol.dto.subDto;
+
+import com.brandol.domain.Brand;
+import com.brandol.domain.enums.MemberListStatus;
+import com.brandol.domain.mapping.MemberBrandList;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrandHeader {
+    private Brand brand;
+    private BrandList brandList;
+    private int recentFanCount;
+
+    public static Map<String,Object> createBrandFandomHeader(Brand brand, MemberBrandList memberBrandList, int recentFanCount){
+        Map<String,Object> result = new LinkedHashMap<>();
+
+        // 브랜드 정보
+        Map<String,Object> brandInfo = new LinkedHashMap<>();
+        brandInfo.put("brand-id",brand.getId());
+        brandInfo.put("brand-fan",recentFanCount);
+        brandInfo.put("brand-name",brand.getName());
+        brandInfo.put("brand-desc",brand.getDescription());
+        brandInfo.put("brand-profile",brand.getProfileImage());
+        brandInfo.put("brand-background",brand.getBackgroundImage());
+
+        //유저 상태
+        Map<String,Object> userStatus = new LinkedHashMap<>();
+
+        // 브랜드리스트에서 status가 subscribe 인 경우
+        if( memberBrandList!= null && memberBrandList.getMemberListStatus() == MemberListStatus.SUBSCRIBED){
+            userStatus.put("is-fan",true);
+            userStatus.put("join-date",memberBrandList.getCreatedAt()); //최초 가입일
+            userStatus.put("fan-sequence",memberBrandList.getSequence()); //최초 가입시 가입 서열
+        }
+        else{ // 브랜드 리스트가 null +브랜드리스트에서 status가 unsubscribe 인경우
+            userStatus.put("is-fan",false);
+        }
+        result.put("brand-info",brandInfo);
+        result.put("user-status",userStatus);
+
+        return result;
+    }
+}

--- a/src/main/java/com/brandol/repository/FandomRepository.java
+++ b/src/main/java/com/brandol/repository/FandomRepository.java
@@ -1,0 +1,18 @@
+package com.brandol.repository;
+
+import com.brandol.domain.Fandom;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FandomRepository extends JpaRepository<Fandom,Long> {
+
+    @Query("select f from Fandom f where f.brand.id= :brandId and f.fandomType = com.brandol.domain.enums.FandomType.CULTURE order by f.createdAt desc ")
+    List<Fandom> getSomeRecentFandomCultures(@Param("brandId")Long brandId, Pageable pageable);
+
+    @Query("select f from Fandom f where f.brand.id= :brandId and f.fandomType = com.brandol.domain.enums.FandomType.ANNOUNCEMENT order by f.createdAt desc ")
+    List<Fandom> getSomeRecentFandomNotices(@Param("brandId")Long brandId, Pageable pageable);
+}

--- a/src/main/java/com/brandol/repository/MemberBrandRepository.java
+++ b/src/main/java/com/brandol/repository/MemberBrandRepository.java
@@ -19,7 +19,7 @@ public interface MemberBrandRepository extends JpaRepository<MemberBrandList,Lon
     @Query("select mbl from MemberBrandList mbl where mbl.member.id = :memberId and mbl.brand.id = :brandId")
     List<MemberBrandList> findOneByMemberIdAndBrandId(@Param("memberId")Long memberId,@Param("brandId") Long brandId);
 
-    @Query("select mbl from MemberBrandList mbl where mbl.brand.id = :id order by mbl.sequence")
+    @Query("select mbl from MemberBrandList mbl where mbl.brand.id = :id order by mbl.sequence desc ")
     List<MemberBrandList> getBrandJoinedFanCount(@Param("id")Long id, Pageable pageable);
 
     @Query("select count(mbl) from MemberBrandList mbl where mbl.memberListStatus = com.brandol.domain.enums.MemberListStatus.SUBSCRIBED")

--- a/src/main/java/com/brandol/repository/MemberBrandRepository.java
+++ b/src/main/java/com/brandol/repository/MemberBrandRepository.java
@@ -1,10 +1,6 @@
 package com.brandol.repository;
 
-import com.brandol.domain.Brand;
-import com.brandol.domain.Member;
-import com.brandol.domain.enums.MemberListStatus;
 import com.brandol.domain.mapping.MemberBrandList;
-import com.brandol.dto.subDto.BrandList;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -26,4 +22,6 @@ public interface MemberBrandRepository extends JpaRepository<MemberBrandList,Lon
     @Query("select mbl from MemberBrandList mbl where mbl.brand.id = :id order by mbl.sequence")
     List<MemberBrandList> getBrandJoinedFanCount(@Param("id")Long id, Pageable pageable);
 
+    @Query("select count(mbl) from MemberBrandList mbl where mbl.memberListStatus = com.brandol.domain.enums.MemberListStatus.SUBSCRIBED")
+    int getRecentSubscriberCount();
 }

--- a/src/main/java/com/brandol/service/BrandService.java
+++ b/src/main/java/com/brandol/service/BrandService.java
@@ -3,17 +3,28 @@ package com.brandol.service;
 import com.brandol.apiPayload.code.status.ErrorStatus;
 import com.brandol.apiPayload.exception.ErrorHandler;
 import com.brandol.domain.Brand;
+import com.brandol.domain.Fandom;
+import com.brandol.domain.Member;
+import com.brandol.domain.mapping.MemberBrandList;
 import com.brandol.dto.request.AddBrandRequest;
+import com.brandol.dto.response.BrandCommonHeaderResponse;
+import com.brandol.dto.response.BrandFandomBodyResponse;
+import com.brandol.dto.subDto.BrandFandomBody;
+import com.brandol.dto.subDto.BrandHeader;
 import com.brandol.repository.BrandRepository;
+import com.brandol.repository.FandomRepository;
+import com.brandol.repository.MemberBrandRepository;
 import com.brandol.storagy.AmazonS3Manager;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -23,6 +34,8 @@ import java.util.UUID;
 public class BrandService {
 
     private final BrandRepository brandRepository;
+    private final MemberBrandRepository memberBrandRepository;
+    private final FandomRepository fandomRepository;
     private final AmazonS3Manager s3Manager;
 
     public List<Brand>findRecentBrands(int cnt){
@@ -48,20 +61,21 @@ public class BrandService {
 
     @Transactional
     public Brand createBrand(AddBrandRequest request){ // 브랜드 등록 함수
-
+        System.out.println("************************************* -2-");
         Brand brand = AddBrandRequest.toEntity(request); // dto에서 이름,설명 데이터만 우선으로 엔티티로 변환
-
         String profileName = request.getProfileImage().getOriginalFilename(); // dto에 담긴 포로필 파일명 추출
         if(profileName.length() == 0){ throw new ErrorHandler(ErrorStatus._FILE_NAME_ERROR);}
         String profileIMGExtension = profileName.substring(profileName.lastIndexOf(".")+1); // 프로필 파일명에서 확자자 추출 (jpg/png)
         String profileUUID = UUID.randomUUID()+"."+profileIMGExtension; //uuid + . + 확장자 => 파일명 생성
-        String profileURL = s3Manager.uploadFile(profileUUID, request.getProfileImage()); // S3 해당 파일명으로 파일 업로드
+        //String profileURL = s3Manager.uploadFile(profileUUID, request.getProfileImage()); // S3 해당 파일명으로 파일 업로드
+        String profileURL = s3Manager.uploadFile(profileUUID, request.getProfileImage());
 
 
         String backgroundName = request.getBackgroundImage().getOriginalFilename();
         if(backgroundName.length() == 0){ throw new ErrorHandler(ErrorStatus._FILE_NAME_ERROR);}
         String backgroundExtension = backgroundName.substring(profileName.lastIndexOf(".")+1);
         String backgroundUUID = UUID.randomUUID()+"."+backgroundExtension;
+        //String backgroundURL = s3Manager.uploadFile(backgroundUUID, request.getBackgroundImage());
         String backgroundURL = s3Manager.uploadFile(backgroundUUID, request.getBackgroundImage());
 
         brand.addImages(profileURL,backgroundURL); // 프로필, 배경 이미지의 url 주소를 엔티티에 할당
@@ -70,9 +84,51 @@ public class BrandService {
 
         return brandRepository.findOneById(savedBrandId);
     }
-
     public boolean isExistBrand(Long id){
         return brandRepository.existsById(id);
+    }
+
+    public BrandCommonHeaderResponse makeBrandCommonHeader(Long brandId, Long memberId){
+
+        //브랜드
+        Brand targetBrand = brandRepository.findOneById(brandId);
+        //멤버브랜드리스트
+        MemberBrandList memberBrandList;
+        List<MemberBrandList> memberBrandLists = memberBrandRepository.findOneByMemberIdAndBrandId(memberId,brandId);
+        if(memberBrandLists.size()==1){
+            memberBrandList = memberBrandLists.get(0); // 구독 기록이 존재하는 경우
+            //memberBrandList = null; // 기존에 구독하지 않았던 브랜드인 경우
+        }
+        else if(memberBrandLists.size() > 1 ){
+            throw new ErrorHandler(ErrorStatus._DUPLICATE_DATABASE_ERROR);
+        }
+        else {
+            memberBrandList = null; // 기존에 구독하지 않았던 브랜드인 경우
+        }
+        //현재 팬 숫자
+        int recentSubscriberCount = memberBrandRepository.getRecentSubscriberCount();
+        // 헤더 생성
+        Map<String,Object> header= BrandHeader.createBrandFandomHeader(targetBrand,memberBrandList,recentSubscriberCount);
+
+        return BrandCommonHeaderResponse.makeBrandHeader(header);
+    }
+    public BrandFandomBodyResponse makeBrandFandomBody(Long brandId){
+
+        Brand targetBrand = brandRepository.findOneById(brandId);
+        //팬덤 컬처 리스트
+        List<Fandom> fandomCultureList = fandomRepository.getSomeRecentFandomCultures(brandId, PageRequest.of(0,2));
+        // 팬덤 노티스 리스트
+        List<Fandom> fandomNoticeList = fandomRepository.getSomeRecentFandomNotices(brandId, PageRequest.of(0,2));
+
+        /*더미 데이터*/
+        //어드민 멤버
+        Member adminMember = Member.builder()
+                .name(targetBrand.getName()+"관리자")
+                .avatar(targetBrand.getBackgroundImage())
+                .build();
+
+        Map<String,Object> body = BrandFandomBody.createFandomBody(fandomCultureList,fandomNoticeList,adminMember);
+        return BrandFandomBodyResponse.makeBrandBody(body);
     }
 
 }

--- a/src/main/java/com/brandol/service/MemberBrandService.java
+++ b/src/main/java/com/brandol/service/MemberBrandService.java
@@ -26,7 +26,7 @@ import java.util.Map;
 @ToString
 public class MemberBrandService {
 
-
+    private final MemberRepository memberRepository;
     private final BrandRepository brandRepository;
     private final ContentsRepository contentsRepository;
     private final MemberBrandRepository memberBrandRepository;
@@ -34,6 +34,7 @@ public class MemberBrandService {
     @Transactional
     public MemberMainPageResponse createMemberMainPage(Long memberId){
 
+        if(memberRepository.findOneById(memberId)==null){throw new ErrorHandler(ErrorStatus._NOT_EXIST_MEMBER);}
         // 메인배너
         List<Brand> mainBannerBrands = new ArrayList<>();
         Brand brandol = brandRepository.findOneByName("brandol");
@@ -63,7 +64,8 @@ public class MemberBrandService {
         List<MemberBrandList> searchResult = memberBrandRepository.findOneByMemberIdAndBrandId(memberId,brandId);
         int size = searchResult.size();
         if(size >1 || size ==0 ){
-            throw  new RuntimeException("'멤버-브랜드-리스트'조회 실패");
+            if(size >1){throw  new ErrorHandler(ErrorStatus._DUPLICATE_DATABASE_ERROR);} //중복 조회 케이스
+            throw new ErrorHandler(ErrorStatus._NOT_EXIST_MEMBER_BRAND_LIST); //조회 실패
         }
         MemberBrandList target = searchResult.get(0);
         target.changeMemberListStatus(MemberListStatus.UNSUBSCRIBED); //더티 체킹

--- a/src/main/java/com/brandol/service/MemberService.java
+++ b/src/main/java/com/brandol/service/MemberService.java
@@ -52,7 +52,7 @@ public class MemberService {
             return memberBrandList.getId();
             }
             else { //중복 구독을 신청한 경우
-                throw new ErrorHandler(ErrorStatus._ALREADY_EXIST_MEMBERM_BRAND_LIST);
+                throw new ErrorHandler(ErrorStatus._ALREADY_EXIST_MEMBER_BRAND_LIST);
             }
         }
 

--- a/src/main/java/com/brandol/service/MemberService.java
+++ b/src/main/java/com/brandol/service/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
     public Long addMemberBrandList(Long memberId, Long brandId){ //멤버가 멤버브랜드리스트에 브랜드를 추가 하는 함수
 
         Member member = memberRepository.findOneById(memberId);
-        if(member == null){throw new RuntimeException("멤버 조회 실패");}
+        if(member == null){throw new ErrorHandler(ErrorStatus._NOT_EXIST_MEMBER);}
 
         Brand brand = brandRepository.findOneById(brandId);
         if(brand == null){
@@ -43,12 +43,16 @@ public class MemberService {
         List<MemberBrandList> memberBrandLists = memberBrandRepository.findOneByMemberIdAndBrandId(memberId,brandId);
         int len = memberBrandLists.size();
 
-        //기존에 구독 취소했던 브랜드를 다시 구독하는 경우
+        //기존에 구독했던 기록이 존재하는 경우
         if(len == 1){
             MemberBrandList memberBrandList=memberBrandLists.get(0);
-            if(memberBrandList.getMemberListStatus() == MemberListStatus.UNSUBSCRIBED){
+
+            if(memberBrandList.getMemberListStatus() == MemberListStatus.UNSUBSCRIBED){ // 구독을 취소한 경우
             memberBrandList.changeMemberListStatus(MemberListStatus.SUBSCRIBED);
             return memberBrandList.getId();
+            }
+            else { //중복 구독을 신청한 경우
+                throw new ErrorHandler(ErrorStatus._ALREADY_EXIST_MEMBERM_BRAND_LIST);
             }
         }
 

--- a/src/main/java/com/brandol/validation/annotation/ExistBrand.java
+++ b/src/main/java/com/brandol/validation/annotation/ExistBrand.java
@@ -8,7 +8,7 @@ import java.lang.annotation.*;
 
 @Documented
 @Constraint(validatedBy = BrandExistValidator.class)
-@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ExistBrand {
         String message() default "해당 브랜드가 존재하지 않습니다.";


### PR DESCRIPTION
피그마 기준 2페이지 a 기능 전체 구현 완료
header:  브랜드 이름, 소개 프로필 이미지, 배경이미지
body: 브랜드 팬덤의 팬덤 컬처/ 팬덤 공지사항 
각각 2개의 엔드 포인트로 구성됨

*중요*
admin 계정은 이후 도입 예정/ 현재는 작성자 명이 브랜드명+관리자 이름으로 표기됨 => writerID null 처리상태

![2페이지 a 바디](https://github.com/yongiCorp/Server/assets/76873740/43e87a39-0647-4782-8e81-1c998b2d0c89)
![2페이지 a 헤더](https://github.com/yongiCorp/Server/assets/76873740/8730d9bd-de9e-4e42-8e17-3b9bbdeafca7)
