### PR TITLE
Feat/18 FandomImage 엔티티 추가 및 팬덤 페이지 Response 사진 URL 추가

### DIFF
--- a/src/main/java/com/brandol/domain/FandomImage.java
+++ b/src/main/java/com/brandol/domain/FandomImage.java
@@ -1,0 +1,26 @@
+package com.brandol.domain;
+
+import com.brandol.domain.common.BaseEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FandomImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="fandom_image_id")
+    private Long id;
+
+    @Column(columnDefinition = "TEXT")
+    private String image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fandom_id", nullable = false)
+    private Fandom fandom;
+}

--- a/src/main/java/com/brandol/dto/subDto/BrandFandomBody.java
+++ b/src/main/java/com/brandol/dto/subDto/BrandFandomBody.java
@@ -1,6 +1,7 @@
 package com.brandol.dto.subDto;
 
 import com.brandol.domain.Fandom;
+import com.brandol.domain.FandomImage;
 import com.brandol.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,7 +18,11 @@ public class BrandFandomBody {
     private List<Fandom> fandomList = new ArrayList<>();
     private Member adminMember;
 
-    public static Map<String,Object> createFandomBody(List<Fandom>fandomCultureList,List<Fandom>fandomNoticeList,Member adminMember){
+    public static Map<String,Object> createFandomBody(List<Fandom>fandomCultureList,
+                                                      List<Fandom>fandomNoticeList,
+                                                      Map<Integer,Object> fandomCultureImages,
+                                                      Map<Integer,Object> fandomNoticeImages,
+                                                      Member adminMember){
         Map<String,Object> result = new LinkedHashMap<>();
 
         //팬덤컬처
@@ -31,13 +36,14 @@ public class BrandFandomBody {
             fandomCultureData.put("writer-profile", adminMember.getAvatar());
             fandomCultureData.put("title",fandomCultureList.get(i).getTitle());
             fandomCultureData.put("content",fandomCultureList.get(i).getContent());
+            fandomCultureData.put("images",fandomCultureImages.get(i));
             fandomCultureData.put("like-count",fandomCultureList.get(i).getLikes());
             fandomCultureData.put("comment-count",fandomCultureList.get(i).getComments());
             fandomCultureData.put("written-date",fandomCultureList.get(i).getCreatedAt());
             fandomCulture.put(key,fandomCultureData);
         }
 
-        //팬덤 노티스
+        //팬덤 아나운스먼트
         Map<String,Object> fandomNotice = new LinkedHashMap<>();
         int fandomNoticeLen = fandomNoticeList.size();
         for(int i=0;i<fandomNoticeLen;i++){
@@ -46,10 +52,11 @@ public class BrandFandomBody {
             fandomNoticeData.put("writer-id",adminMember.getId());
             fandomNoticeData.put("writer",adminMember.getName());
             fandomNoticeData.put("writer-profile",adminMember.getAvatar());
-            fandomNoticeData.put("title",fandomCultureList.get(i).getTitle());
-            fandomNoticeData.put("content",fandomCultureList.get(i).getContent());
-            fandomNoticeData.put("like-count",fandomCultureList.get(i).getLikes());
-            fandomNoticeData.put("comment-count",fandomCultureList.get(i).getComments());
+            fandomNoticeData.put("title",fandomNoticeList.get(i).getTitle());
+            fandomNoticeData.put("content",fandomNoticeList.get(i).getContent());
+            fandomNoticeData.put("images",fandomNoticeImages.get(i));
+            fandomNoticeData.put("like-count",fandomNoticeList.get(i).getLikes());
+            fandomNoticeData.put("comment-count",fandomNoticeList.get(i).getComments());
             fandomNoticeData.put("written-date",fandomNoticeList.get(i).getCreatedAt());
             fandomNotice.put(key,fandomNoticeData);
         }

--- a/src/main/java/com/brandol/repository/FandomImageRepository.java
+++ b/src/main/java/com/brandol/repository/FandomImageRepository.java
@@ -1,0 +1,14 @@
+package com.brandol.repository;
+
+import com.brandol.domain.FandomImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FandomImageRepository extends JpaRepository<FandomImage,Long> {
+
+    @Query("select fi from FandomImage fi where fi.fandom.id = :fandomId order by fi.createdAt asc ")
+    List<FandomImage> findFandomImages(@Param("fandomId")Long fandomId);
+}


### PR DESCRIPTION
팬덤 페이지 이미지 기능 추가에 따른(이미지 최대 10장)  FandomImage 엔티티 도입,
팬덤 페이지 Response시 팬덤 컬처와 팬덤 공지에 각 게시물의 사진이 포함되어 Response 되도록 수정