### PR TITLE
[Feat/57] 브랜드 게시판별 게시글 전체 조회(페이징)/ 단건 조회 API

### DIFF
--- a/src/main/java/com/brandol/config/SecurityConfig.java
+++ b/src/main/java/com/brandol/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring().antMatchers(
-                "/**", // 테스트용으로 비활성화
+               // "/**", // 테스트용으로 비활성화
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
                 "/swagger-resources/**",

--- a/src/main/java/com/brandol/config/SecurityConfig.java
+++ b/src/main/java/com/brandol/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring().antMatchers(
-                //"/**", // 테스트용으로 비활성화
+                "/**", // 테스트용으로 비활성화
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
                 "/swagger-resources/**",

--- a/src/main/java/com/brandol/controller/BrandController.java
+++ b/src/main/java/com/brandol/controller/BrandController.java
@@ -67,9 +67,9 @@ public class BrandController {
     @PostMapping(value = "/brands/{brandId}/community/new",consumes = "multipart/form-data")
     public ApiResponse<String> crateBrandCommunity(@ModelAttribute BrandRequestDto.addCommunity communityDto,
                                                    @PathVariable("brandId")Long brandId,
-                                                   Authentication authentication
+                                                   @RequestParam("memberId") Long memberID
                                                    ){
-        Long memberId = Long.parseLong(authentication.getName());
+        Long memberId = memberID;
         Long communityId = brandService.createCommunity(communityDto,brandId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"article-id: "+communityId);
     }

--- a/src/main/java/com/brandol/controller/CommentController.java
+++ b/src/main/java/com/brandol/controller/CommentController.java
@@ -42,4 +42,5 @@ public class CommentController {
         return  ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"CommunityCommentId: "+ commentId);
     }
 
+
 }

--- a/src/main/java/com/brandol/controller/CommunityController.java
+++ b/src/main/java/com/brandol/controller/CommunityController.java
@@ -36,4 +36,11 @@ public class CommunityController {
         List<CommunityResponseDto.CommunityDto> communityDtoList = communityService.showAllCommunityFeedBack(pageNumber,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), communityDtoList);
     }
+
+    @Operation(summary = "커뮤니티 게시글 조회 ",description ="커뮤니티 게시글 상세조회")
+    @GetMapping("/brands/communities/{communityId}")
+    public ApiResponse<CommunityResponseDto.CommunityDto> communityArticle(@PathVariable("communityId")Long communityId){
+        CommunityResponseDto.CommunityDto dto =communityService.showOneCommunityArticle(communityId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
+    }
 }

--- a/src/main/java/com/brandol/controller/CommunityController.java
+++ b/src/main/java/com/brandol/controller/CommunityController.java
@@ -1,0 +1,39 @@
+package com.brandol.controller;
+
+
+import com.brandol.apiPayload.ApiResponse;
+import com.brandol.apiPayload.code.status.SuccessStatus;
+import com.brandol.dto.response.CommunityResponseDto;
+import com.brandol.dto.response.ContentsResponseDto;
+import com.brandol.service.CommunityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "커뮤니티 게시판 관련 API")
+public class CommunityController {
+
+    private final CommunityService communityService;
+
+    @Operation(summary = "커뮤니티 자유게시판 전체조회 ",description ="커뮤니티 자유게시판 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/community-free")
+    public ApiResponse<List<CommunityResponseDto.CommunityDto>> allCommunityAll(@PathVariable("brandId")Long brandId, @RequestParam("page")Integer pageNumber){
+        List<CommunityResponseDto.CommunityDto> communityDtoList = communityService.showAllCommunityAll(pageNumber,brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), communityDtoList);
+    }
+
+    @Operation(summary = "커뮤니티 피드백게시판 전체조회 ",description ="커뮤니티 피드게시판 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/community-feedback")
+    public ApiResponse<List<CommunityResponseDto.CommunityDto>> allCommunityFeedback(@PathVariable("brandId")Long brandId, @RequestParam("page")Integer pageNumber){
+        List<CommunityResponseDto.CommunityDto> communityDtoList = communityService.showAllCommunityFeedBack(pageNumber,brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), communityDtoList);
+    }
+}

--- a/src/main/java/com/brandol/controller/ContentsController.java
+++ b/src/main/java/com/brandol/controller/ContentsController.java
@@ -22,22 +22,22 @@ public class ContentsController {
 
     private final ContentsService contentsService;
 
-    @Operation(summary = "콘텐츠 카드뉴스 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
-    @GetMapping("/brands/{brandId}/contents-cardnews/all")
+    @Operation(summary = "콘텐츠 카드뉴스 게시판 전체조회 ",description ="콘텐츠 카드뉴스 게시판 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/contents-cardnews")
     public ApiResponse<List<ContentsResponseDto.ContentsDto>> allContentsCardNews(@PathVariable("brandId")Long brandId,@RequestParam("page")Integer pageNumber){
         List<ContentsResponseDto.ContentsDto> contentsDtoList = contentsService.showAllContentsCardNews(pageNumber,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), contentsDtoList);
     }
 
-    @Operation(summary = "콘텐츠 이벤트 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
-    @GetMapping("/brands/{brandId}/contents-event/all")
+    @Operation(summary = "콘텐츠 이벤트 게시판 전체조회 ",description ="콘텐츠 이벤트 게사판 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/contents-events")
     public ApiResponse<List<ContentsResponseDto.ContentsDto>> allContentsEvents(@PathVariable("brandId")Long brandId,@RequestParam("page")Integer pageNumber){
         List<ContentsResponseDto.ContentsDto> contentsDtoList = contentsService.showAllContentsEvents(pageNumber,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), contentsDtoList);
     }
 
-    @Operation(summary = "콘텐츠 비디오 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
-    @GetMapping("/brands/{brandId}/contents-video/all")
+    @Operation(summary = "콘텐츠 비디오 게시판 전체조회 ",description ="콘텐츠 비디오 게시판 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/contents-videos")
     public ApiResponse<List<ContentsResponseDto.ContentsDto>> allContentsVideos(@PathVariable("brandId")Long brandId, @RequestParam("page")Integer pageNumber){
         List<ContentsResponseDto.ContentsDto> contentsDtoList = contentsService.showAllContentsVideos(pageNumber,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), contentsDtoList);

--- a/src/main/java/com/brandol/controller/ContentsController.java
+++ b/src/main/java/com/brandol/controller/ContentsController.java
@@ -1,0 +1,46 @@
+package com.brandol.controller;
+
+
+import com.brandol.apiPayload.ApiResponse;
+import com.brandol.apiPayload.code.status.SuccessStatus;
+import com.brandol.dto.response.ContentsResponseDto;
+import com.brandol.service.ContentsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "콘텐츠 게시판 관련 API")
+public class ContentsController {
+
+    private final ContentsService contentsService;
+
+    @Operation(summary = "콘텐츠 카드뉴스 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/contents-cardnews/all")
+    public ApiResponse<List<ContentsResponseDto.ContentsDto>> allContentsCardNews(@PathVariable("brandId")Long brandId,@RequestParam("page")Integer pageNumber){
+        List<ContentsResponseDto.ContentsDto> contentsDtoList = contentsService.showAllContentsCardNews(pageNumber,brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), contentsDtoList);
+    }
+
+    @Operation(summary = "콘텐츠 이벤트 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/contents-event/all")
+    public ApiResponse<List<ContentsResponseDto.ContentsDto>> allContentsEvents(@PathVariable("brandId")Long brandId,@RequestParam("page")Integer pageNumber){
+        List<ContentsResponseDto.ContentsDto> contentsDtoList = contentsService.showAllContentsEvents(pageNumber,brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), contentsDtoList);
+    }
+
+    @Operation(summary = "콘텐츠 비디오 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/contents-video/all")
+    public ApiResponse<List<ContentsResponseDto.ContentsDto>> allContentsVideos(@PathVariable("brandId")Long brandId, @RequestParam("page")Integer pageNumber){
+        List<ContentsResponseDto.ContentsDto> contentsDtoList = contentsService.showAllContentsVideos(pageNumber,brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), contentsDtoList);
+    }
+
+}

--- a/src/main/java/com/brandol/controller/ContentsController.java
+++ b/src/main/java/com/brandol/controller/ContentsController.java
@@ -43,4 +43,10 @@ public class ContentsController {
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), contentsDtoList);
     }
 
+    @Operation(summary = "콘텐츠 게시글 조회 ",description ="콘텐츠 게시글 상세조회")
+    @GetMapping("/brands/contents/{contentsId}")
+    public ApiResponse<ContentsResponseDto.ContentsDto> contentsArticle(@PathVariable("contentsId")Long contentsId){
+        ContentsResponseDto.ContentsDto dto = contentsService.showOneContentsArticle(contentsId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
+    }
 }

--- a/src/main/java/com/brandol/controller/FandomController.java
+++ b/src/main/java/com/brandol/controller/FandomController.java
@@ -22,15 +22,15 @@ public class FandomController {
 
     private final FandomService fandomService;
 
-    @Operation(summary = "팬덤 컬처 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
-    @GetMapping("/brands/{brandId}/fandom-culture/all")
+    @Operation(summary = "팬덤 컬처 게시판 전체조회 ",description ="팬덤 컬처 게시물 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/fandom-cultures")
     public ApiResponse<List<FandomResponseDto.FandomDto>>allFandomCultures(@PathVariable("brandId")Long brandId,@RequestParam("page")Integer pageNumber){
         List<FandomResponseDto.FandomDto> fandomDtoList = fandomService.showAllFandomCultures(pageNumber,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), fandomDtoList);
     }
 
-    @Operation(summary = "팬덤 아나운스먼트 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
-    @GetMapping("/brands/{brandId}/fandom-announcement/all")
+    @Operation(summary = "팬덤 아나운스먼트 게시판 전체조회 ",description ="팬덤 아나운스먼트 게시물 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/fandom-announcements")
     public ApiResponse<List<FandomResponseDto.FandomDto>>allFandomAnnouncements(@PathVariable("brandId")Long brandId,@RequestParam("page")Integer pageNumber){
         List<FandomResponseDto.FandomDto> fandomDtoList = fandomService.showAllFandomAnnouncement(pageNumber,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), fandomDtoList);

--- a/src/main/java/com/brandol/controller/FandomController.java
+++ b/src/main/java/com/brandol/controller/FandomController.java
@@ -1,0 +1,38 @@
+package com.brandol.controller;
+
+import com.brandol.apiPayload.ApiResponse;
+import com.brandol.apiPayload.code.status.SuccessStatus;
+import com.brandol.dto.response.FandomResponseDto;
+import com.brandol.service.FandomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "팬덤 게시판 관련 API")
+public class FandomController {
+
+    private final FandomService fandomService;
+
+    @Operation(summary = "팬덤 컬처 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/fandom-culture/all")
+    public ApiResponse<List<FandomResponseDto.FandomDto>>allFandomCultures(@PathVariable("brandId")Long brandId,@RequestParam("page")Integer pageNumber){
+        List<FandomResponseDto.FandomDto> fandomDtoList = fandomService.showAllFandomCultures(pageNumber,brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), fandomDtoList);
+    }
+
+    @Operation(summary = "팬덤 아나운스먼트 게시판 전체조회 ",description ="팬덤 컬체 게시물 전체 조회(페이징: 0페이지 부터 시작)")
+    @GetMapping("/brands/{brandId}/fandom-announcement/all")
+    public ApiResponse<List<FandomResponseDto.FandomDto>>allFandomAnnouncements(@PathVariable("brandId")Long brandId,@RequestParam("page")Integer pageNumber){
+        List<FandomResponseDto.FandomDto> fandomDtoList = fandomService.showAllFandomAnnouncement(pageNumber,brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), fandomDtoList);
+    }
+}

--- a/src/main/java/com/brandol/controller/FandomController.java
+++ b/src/main/java/com/brandol/controller/FandomController.java
@@ -35,4 +35,11 @@ public class FandomController {
         List<FandomResponseDto.FandomDto> fandomDtoList = fandomService.showAllFandomAnnouncement(pageNumber,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), fandomDtoList);
     }
+
+    @Operation(summary = "팬덤 게시글 조회 ",description ="팬덤 게시글 상세조회")
+    @GetMapping("/brands/fandoms/{fandomId}")
+    public ApiResponse<FandomResponseDto.FandomDto> FandomArticle(@PathVariable("fandomId")Long fandomId){
+        FandomResponseDto.FandomDto dto = fandomService.showOneFandomArticle(fandomId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
+    }
 }

--- a/src/main/java/com/brandol/converter/CommunityConverter.java
+++ b/src/main/java/com/brandol/converter/CommunityConverter.java
@@ -1,0 +1,36 @@
+package com.brandol.converter;
+
+import com.brandol.domain.Contents;
+import com.brandol.domain.Member;
+import com.brandol.domain.mapping.Community;
+import com.brandol.dto.response.CommunityResponseDto;
+import com.brandol.dto.response.ContentsResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommunityConverter {
+
+    public static CommunityResponseDto.CommunityDto toContentsDto(
+            Community community,
+            List<String> communityImages,
+            Member member){
+        return CommunityResponseDto.CommunityDto.builder()
+                .writerId(member.getId())
+                .writerName(member.getName())
+                .writerProfile(member.getAvatar())
+                .communityId(community.getId())
+                .title(community.getTitle())
+                .content(community.getContent())
+                .images(communityImages)
+                .likeCount(community.getLikes())
+                .commentCount(community.getComments())
+                .writtenDate(community.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/brandol/converter/ContentsConverter.java
+++ b/src/main/java/com/brandol/converter/ContentsConverter.java
@@ -1,0 +1,34 @@
+package com.brandol.converter;
+
+import com.brandol.domain.Contents;
+import com.brandol.domain.Member;
+import com.brandol.dto.response.ContentsResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ContentsConverter {
+
+    public static ContentsResponseDto.ContentsDto toContentsDto(
+            Contents contents,
+            List<String> contentsImages,
+            Member member){
+        return ContentsResponseDto.ContentsDto.builder()
+                .writerId(member.getId())
+                .writerName(member.getName())
+                .writerProfile(member.getAvatar())
+                .contentsId(contents.getId())
+                .title(contents.getTitle())
+                .content(contents.getContent())
+                .images(contentsImages)
+                .likeCount(contents.getLikes())
+                .commentCount(contents.getComments())
+                .writtenDate(contents.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/brandol/converter/ContentsConverter.java
+++ b/src/main/java/com/brandol/converter/ContentsConverter.java
@@ -26,6 +26,7 @@ public class ContentsConverter {
                 .title(contents.getTitle())
                 .content(contents.getContent())
                 .images(contentsImages)
+                .file(contents.getFile())
                 .likeCount(contents.getLikes())
                 .commentCount(contents.getComments())
                 .writtenDate(contents.getCreatedAt())

--- a/src/main/java/com/brandol/converter/FandomConverter.java
+++ b/src/main/java/com/brandol/converter/FandomConverter.java
@@ -1,0 +1,35 @@
+package com.brandol.converter;
+
+import com.brandol.domain.Fandom;
+import com.brandol.domain.Member;
+import com.brandol.dto.response.BrandResponseDto;
+import com.brandol.dto.response.FandomResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FandomConverter {
+
+    public static FandomResponseDto.FandomDto toFandomDto(
+            Fandom fandom,
+            List<String> fandomImages,
+            Member member){
+        return FandomResponseDto.FandomDto.builder()
+                .writerId(member.getId())
+                .writerName(member.getName())
+                .writerProfile(member.getAvatar())
+                .fandomId(fandom.getId())
+                .title(fandom.getTitle())
+                .content(fandom.getContent())
+                .images(fandomImages)
+                .likeCount(fandom.getLikes())
+                .commentCount(fandom.getComments())
+                .writtenDate(fandom.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/brandol/dto/response/CommunityResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/CommunityResponseDto.java
@@ -1,0 +1,26 @@
+package com.brandol.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CommunityResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class CommunityDto{
+        private Long writerId;
+        private String writerName;
+        private String writerProfile;
+        private Long communityId;
+        private String title;
+        private String content;
+        private List<String> images;
+        private int likeCount;
+        private int commentCount;
+        private LocalDateTime writtenDate;
+    }
+}

--- a/src/main/java/com/brandol/dto/response/ContentsResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/ContentsResponseDto.java
@@ -19,6 +19,7 @@ public class ContentsResponseDto {
         private String title;
         private String content;
         private List<String> images;
+        private String file;
         private int likeCount;
         private int commentCount;
         private LocalDateTime writtenDate;

--- a/src/main/java/com/brandol/dto/response/ContentsResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/ContentsResponseDto.java
@@ -1,0 +1,26 @@
+package com.brandol.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ContentsResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ContentsDto{
+        private Long writerId;
+        private String writerName;
+        private String writerProfile;
+        private Long contentsId;
+        private String title;
+        private String content;
+        private List<String> images;
+        private int likeCount;
+        private int commentCount;
+        private LocalDateTime writtenDate;
+    }
+}

--- a/src/main/java/com/brandol/dto/response/FandomResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/FandomResponseDto.java
@@ -1,0 +1,27 @@
+package com.brandol.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class FandomResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FandomDto{
+        private Long writerId;
+        private String writerName;
+        private String writerProfile;
+        private Long fandomId;
+        private String title;
+        private String content;
+        private List<String> images;
+        private int likeCount;
+        private int commentCount;
+        private LocalDateTime writtenDate;
+    }
+
+}

--- a/src/main/java/com/brandol/repository/ContentsRepository.java
+++ b/src/main/java/com/brandol/repository/ContentsRepository.java
@@ -21,6 +21,7 @@ public interface ContentsRepository extends JpaRepository<Contents,Long> {
 
     @Query(value = "select  c from  Contents c where c.brand.id= :brandId and c.contentsType =com.brandol.domain.enums.ContentsType.VIDEOS order by c.createdAt desc ")
     List<Contents>findRecentVideos(@Param("brandId")Long brandId,Pageable pageable);
+
     
     @Query(value = "SELECT * FROM Contents  ORDER BY RAND() limit 3",nativeQuery = true)
     List<Contents> findThreeByRandom();

--- a/src/main/java/com/brandol/repository/FandomRepository.java
+++ b/src/main/java/com/brandol/repository/FandomRepository.java
@@ -15,4 +15,7 @@ public interface FandomRepository extends JpaRepository<Fandom,Long> {
 
     @Query("select f from Fandom f where f.brand.id= :brandId and f.fandomType = com.brandol.domain.enums.FandomType.ANNOUNCEMENT order by f.createdAt desc ")
     List<Fandom> getSomeRecentFandomNotices(@Param("brandId")Long brandId, Pageable pageable);
+
+    @Query("select f from  Fandom f where f.brand.id = :brandId and f.fandomType = com.brandol.domain.enums.FandomType.CULTURE")
+    List<Fandom> getFandomCulturesByBrandId(@Param("brandId")Long brandId,Pageable pageable);
 }

--- a/src/main/java/com/brandol/service/CommunityService.java
+++ b/src/main/java/com/brandol/service/CommunityService.java
@@ -1,5 +1,7 @@
 package com.brandol.service;
 
+import com.brandol.apiPayload.code.status.ErrorStatus;
+import com.brandol.apiPayload.exception.ErrorHandler;
 import com.brandol.converter.CommunityConverter;
 import com.brandol.domain.Member;
 import com.brandol.domain.mapping.Community;
@@ -60,5 +62,15 @@ public class CommunityService {
             communityDtoList.add(dto);
         }
         return communityDtoList;
+    }
+
+    public CommunityResponseDto.CommunityDto showOneCommunityArticle(Long communityId){
+
+        Community community = communityRepository.findById(communityId).orElseThrow(()-> new ErrorHandler(ErrorStatus._CANNOT_LOAD_COMMUNITY));
+        List<CommunityImage> communityImages = communityImageRepository.findAllByCommunityId(community.getId());
+        List<String>communityImageUrlList = communityImages.stream().map(CommunityImage::getImage).collect(Collectors.toList());
+        Member member = community.getMember();
+
+        return CommunityConverter.toContentsDto(community,communityImageUrlList,member);
     }
 }

--- a/src/main/java/com/brandol/service/CommunityService.java
+++ b/src/main/java/com/brandol/service/CommunityService.java
@@ -1,0 +1,64 @@
+package com.brandol.service;
+
+import com.brandol.converter.CommunityConverter;
+import com.brandol.domain.Member;
+import com.brandol.domain.mapping.Community;
+import com.brandol.domain.mapping.CommunityImage;
+import com.brandol.dto.response.CommunityResponseDto;
+import com.brandol.repository.CommunityImageRepository;
+import com.brandol.repository.CommunityRepository;
+import com.brandol.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommunityService {
+
+    private final CommunityRepository communityRepository;
+    private final CommunityImageRepository communityImageRepository;
+    private final MemberRepository memberRepository;
+
+    public List<CommunityResponseDto.CommunityDto> showAllCommunityAll(Integer pageNumber,Long brandId){
+
+        Pageable pageable = PageRequest.of(pageNumber,15, Sort.by(Sort.Direction.DESC,"createdAt"));
+        List<Community> communityList =communityRepository.findRecentFreeBoard(brandId,pageable);
+
+        List<CommunityResponseDto.CommunityDto> communityDtoList = new ArrayList<>();
+        for(int i= 0;i<communityList.size();i++){
+            Community targetCommunity = communityList.get(i);
+            List<CommunityImage> communityImages = communityImageRepository.findAllByCommunityId(targetCommunity.getId());
+            List<String>communityUrlList = communityImages.stream().map(CommunityImage::getImage).collect(Collectors.toList());
+            Member writer = targetCommunity.getMember();
+            CommunityResponseDto.CommunityDto dto = CommunityConverter.toContentsDto(targetCommunity,communityUrlList,writer);
+            communityDtoList.add(dto);
+        }
+        return communityDtoList;
+    }
+
+    public List<CommunityResponseDto.CommunityDto> showAllCommunityFeedBack(Integer pageNumber,Long brandId){
+
+        Pageable pageable = PageRequest.of(pageNumber,15, Sort.by(Sort.Direction.DESC,"createdAt"));
+        List<Community> communityList =communityRepository.findRecentFeedBackBoard(brandId,pageable);
+
+        List<CommunityResponseDto.CommunityDto> communityDtoList = new ArrayList<>();
+        for(int i= 0;i<communityList.size();i++){
+            Community targetCommunity = communityList.get(i);
+            List<CommunityImage> communityImages = communityImageRepository.findAllByCommunityId(targetCommunity.getId());
+            List<String>communityUrlList = communityImages.stream().map(CommunityImage::getImage).collect(Collectors.toList());
+            Member writer = targetCommunity.getMember();
+            CommunityResponseDto.CommunityDto dto = CommunityConverter.toContentsDto(targetCommunity,communityUrlList,writer);
+            communityDtoList.add(dto);
+        }
+        return communityDtoList;
+    }
+}

--- a/src/main/java/com/brandol/service/ContentsService.java
+++ b/src/main/java/com/brandol/service/ContentsService.java
@@ -36,7 +36,7 @@ public class ContentsService {
             Contents targetContents = contentsList.get(i);
             List<ContentsImage> contentsImages = contentImageRepository.findAllByContentsId(targetContents.getId());
             List<String> contentsUrlList = contentsImages.stream().map(ContentsImage::getImage).collect(Collectors.toList());
-            Member writer = memberRepository.findOneById(targetContents.getMember().getId());
+            Member writer = targetContents.getMember();
             ContentsResponseDto.ContentsDto dto = ContentsConverter.toContentsDto(targetContents,contentsUrlList,writer);
             contentsDtoList.add(dto);
         }
@@ -52,7 +52,7 @@ public class ContentsService {
             Contents targetContents = contentsList.get(i);
             List<ContentsImage> contentsImages = contentImageRepository.findAllByContentsId(targetContents.getId());
             List<String> contentsUrlList = contentsImages.stream().map(ContentsImage::getImage).collect(Collectors.toList());
-            Member writer = memberRepository.findOneById(targetContents.getMember().getId());
+            Member writer = targetContents.getMember();
             ContentsResponseDto.ContentsDto dto = ContentsConverter.toContentsDto(targetContents,contentsUrlList,writer);
             contentsDtoList.add(dto);
         }
@@ -68,7 +68,7 @@ public class ContentsService {
             Contents targetContents = contentsList.get(i);
             List<ContentsImage> contentsImages = contentImageRepository.findAllByContentsId(targetContents.getId());
             List<String> contentsUrlList = contentsImages.stream().map(ContentsImage::getImage).collect(Collectors.toList());
-            Member writer = memberRepository.findOneById(targetContents.getMember().getId());
+            Member writer = targetContents.getMember();
             ContentsResponseDto.ContentsDto dto = ContentsConverter.toContentsDto(targetContents,contentsUrlList,writer);
             contentsDtoList.add(dto);
         }

--- a/src/main/java/com/brandol/service/ContentsService.java
+++ b/src/main/java/com/brandol/service/ContentsService.java
@@ -1,18 +1,77 @@
 package com.brandol.service;
 
-import com.brandol.apiPayload.code.status.ErrorStatus;
-import com.brandol.apiPayload.exception.ErrorHandler;
+import com.brandol.converter.ContentsConverter;
 import com.brandol.domain.Contents;
+import com.brandol.domain.ContentsImage;
+import com.brandol.domain.Member;
+import com.brandol.dto.response.ContentsResponseDto;
+import com.brandol.repository.ContentImageRepository;
 import com.brandol.repository.ContentsRepository;
+import com.brandol.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ContentsService {
     private final ContentsRepository contentsRepository;
+    private final ContentImageRepository contentImageRepository;
+    private final MemberRepository memberRepository;
+
+    public List<ContentsResponseDto.ContentsDto> showAllContentsCardNews(Integer pageNumber,Long brandId){
+        Pageable pageable = PageRequest.of(pageNumber,15, Sort.by(Sort.Direction.DESC,"createdAt"));
+        List<Contents> contentsList = contentsRepository.findRecentCardNews(brandId,pageable);
+
+        List<ContentsResponseDto.ContentsDto> contentsDtoList = new ArrayList<>();
+        for(int i =0; i< contentsList.size();i++){
+            Contents targetContents = contentsList.get(i);
+            List<ContentsImage> contentsImages = contentImageRepository.findAllByContentsId(targetContents.getId());
+            List<String> contentsUrlList = contentsImages.stream().map(ContentsImage::getImage).collect(Collectors.toList());
+            Member writer = memberRepository.findOneById(targetContents.getMember().getId());
+            ContentsResponseDto.ContentsDto dto = ContentsConverter.toContentsDto(targetContents,contentsUrlList,writer);
+            contentsDtoList.add(dto);
+        }
+        return  contentsDtoList;
+    }
+
+    public List<ContentsResponseDto.ContentsDto> showAllContentsEvents(Integer pageNumber,Long brandId){
+        Pageable pageable = PageRequest.of(pageNumber,15, Sort.by(Sort.Direction.DESC,"createdAt"));
+        List<Contents> contentsList = contentsRepository.findRecentEvents(brandId,pageable);
+
+        List<ContentsResponseDto.ContentsDto> contentsDtoList = new ArrayList<>();
+        for(int i =0; i< contentsList.size();i++){
+            Contents targetContents = contentsList.get(i);
+            List<ContentsImage> contentsImages = contentImageRepository.findAllByContentsId(targetContents.getId());
+            List<String> contentsUrlList = contentsImages.stream().map(ContentsImage::getImage).collect(Collectors.toList());
+            Member writer = memberRepository.findOneById(targetContents.getMember().getId());
+            ContentsResponseDto.ContentsDto dto = ContentsConverter.toContentsDto(targetContents,contentsUrlList,writer);
+            contentsDtoList.add(dto);
+        }
+        return  contentsDtoList;
+    }
+
+    public List<ContentsResponseDto.ContentsDto> showAllContentsVideos(Integer pageNumber,Long brandId){
+        Pageable pageable = PageRequest.of(pageNumber,15, Sort.by(Sort.Direction.DESC,"createdAt"));
+        List<Contents> contentsList = contentsRepository.findRecentVideos(brandId,pageable);
+
+        List<ContentsResponseDto.ContentsDto> contentsDtoList = new ArrayList<>();
+        for(int i =0; i< contentsList.size();i++){
+            Contents targetContents = contentsList.get(i);
+            List<ContentsImage> contentsImages = contentImageRepository.findAllByContentsId(targetContents.getId());
+            List<String> contentsUrlList = contentsImages.stream().map(ContentsImage::getImage).collect(Collectors.toList());
+            Member writer = memberRepository.findOneById(targetContents.getMember().getId());
+            ContentsResponseDto.ContentsDto dto = ContentsConverter.toContentsDto(targetContents,contentsUrlList,writer);
+            contentsDtoList.add(dto);
+        }
+        return  contentsDtoList;
+    }
 }

--- a/src/main/java/com/brandol/service/ContentsService.java
+++ b/src/main/java/com/brandol/service/ContentsService.java
@@ -1,10 +1,13 @@
 package com.brandol.service;
 
+import com.brandol.apiPayload.code.status.ErrorStatus;
+import com.brandol.apiPayload.exception.ErrorHandler;
 import com.brandol.converter.ContentsConverter;
 import com.brandol.domain.Contents;
 import com.brandol.domain.ContentsImage;
 import com.brandol.domain.Member;
 import com.brandol.dto.response.ContentsResponseDto;
+import com.brandol.dto.response.FandomResponseDto;
 import com.brandol.repository.ContentImageRepository;
 import com.brandol.repository.ContentsRepository;
 import com.brandol.repository.MemberRepository;
@@ -73,5 +76,15 @@ public class ContentsService {
             contentsDtoList.add(dto);
         }
         return  contentsDtoList;
+    }
+
+    public ContentsResponseDto.ContentsDto showOneContentsArticle(Long contentsId){
+
+        Contents contents = contentsRepository.findById(contentsId).orElseThrow(()-> new ErrorHandler(ErrorStatus._CANNOT_LOAD_CONTENTS));
+        List<ContentsImage> contentsImages = contentImageRepository.findAllByContentsId(contents.getId());
+        List<String> contentsImageUrlList = contentsImages.stream().map(ContentsImage::getImage).collect(Collectors.toList());
+        Member member = contents.getMember();
+
+        return ContentsConverter.toContentsDto(contents,contentsImageUrlList,member);
     }
 }

--- a/src/main/java/com/brandol/service/FandomService.java
+++ b/src/main/java/com/brandol/service/FandomService.java
@@ -1,0 +1,65 @@
+package com.brandol.service;
+
+import com.brandol.converter.FandomConverter;
+import com.brandol.domain.Fandom;
+import com.brandol.domain.FandomImage;
+import com.brandol.domain.Member;
+import com.brandol.dto.response.FandomResponseDto;
+import com.brandol.repository.FandomImageRepository;
+import com.brandol.repository.FandomRepository;
+import com.brandol.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FandomService {
+
+    private final FandomRepository fandomRepository;
+    private final FandomImageRepository fandomImageRepository;
+    private final MemberRepository memberRepository;
+
+    public List<FandomResponseDto.FandomDto> showAllFandomCultures(Integer pageNumber,Long brandId){
+
+        Pageable pageable = PageRequest.of(pageNumber,15, Sort.by(Sort.Direction.DESC,"createdAt"));
+        List<Fandom> fandomList = fandomRepository.getSomeRecentFandomCultures(brandId,pageable);
+
+        List<FandomResponseDto.FandomDto> fandomDtoList = new ArrayList<>();
+        for(int i =0;i<fandomList.size();i++){
+            Fandom targetFandom = fandomList.get(i);
+            List<FandomImage> fandomImages = fandomImageRepository.findFandomImages(targetFandom.getId());
+            List<String> fandomImageUrlList = fandomImages.stream().map(FandomImage::getImage).collect(Collectors.toList());
+            Member writer = memberRepository.findOneById(targetFandom.getMember().getId());
+            FandomResponseDto.FandomDto dto = FandomConverter.toFandomDto(targetFandom,fandomImageUrlList,writer);
+            fandomDtoList.add(dto);
+        }
+        return  fandomDtoList;
+    }
+
+    public List<FandomResponseDto.FandomDto> showAllFandomAnnouncement(Integer pageNumber,Long brandId){
+
+        Pageable pageable = PageRequest.of(pageNumber,15, Sort.by(Sort.Direction.DESC,"createdAt"));
+        List<Fandom> fandomList = fandomRepository.getSomeRecentFandomNotices(brandId,pageable);
+
+        List<FandomResponseDto.FandomDto> fandomDtoList = new ArrayList<>();
+        for(int i =0;i<fandomList.size();i++){
+            Fandom targetFandom = fandomList.get(i);
+            List<FandomImage> fandomImages = fandomImageRepository.findFandomImages(targetFandom.getId());
+            List<String> fandomImageUrlList = fandomImages.stream().map(FandomImage::getImage).collect(Collectors.toList());
+            Member writer = memberRepository.findOneById(targetFandom.getMember().getId());
+            FandomResponseDto.FandomDto dto = FandomConverter.toFandomDto(targetFandom,fandomImageUrlList,writer);
+            fandomDtoList.add(dto);
+        }
+        return  fandomDtoList;
+    }
+
+}

--- a/src/main/java/com/brandol/service/FandomService.java
+++ b/src/main/java/com/brandol/service/FandomService.java
@@ -38,7 +38,7 @@ public class FandomService {
             Fandom targetFandom = fandomList.get(i);
             List<FandomImage> fandomImages = fandomImageRepository.findFandomImages(targetFandom.getId());
             List<String> fandomImageUrlList = fandomImages.stream().map(FandomImage::getImage).collect(Collectors.toList());
-            Member writer = memberRepository.findOneById(targetFandom.getMember().getId());
+            Member writer = targetFandom.getMember();
             FandomResponseDto.FandomDto dto = FandomConverter.toFandomDto(targetFandom,fandomImageUrlList,writer);
             fandomDtoList.add(dto);
         }
@@ -55,7 +55,7 @@ public class FandomService {
             Fandom targetFandom = fandomList.get(i);
             List<FandomImage> fandomImages = fandomImageRepository.findFandomImages(targetFandom.getId());
             List<String> fandomImageUrlList = fandomImages.stream().map(FandomImage::getImage).collect(Collectors.toList());
-            Member writer = memberRepository.findOneById(targetFandom.getMember().getId());
+            Member writer = targetFandom.getMember();
             FandomResponseDto.FandomDto dto = FandomConverter.toFandomDto(targetFandom,fandomImageUrlList,writer);
             fandomDtoList.add(dto);
         }

--- a/src/main/java/com/brandol/service/FandomService.java
+++ b/src/main/java/com/brandol/service/FandomService.java
@@ -1,5 +1,7 @@
 package com.brandol.service;
 
+import com.brandol.apiPayload.code.status.ErrorStatus;
+import com.brandol.apiPayload.exception.ErrorHandler;
 import com.brandol.converter.FandomConverter;
 import com.brandol.domain.Fandom;
 import com.brandol.domain.FandomImage;
@@ -60,6 +62,14 @@ public class FandomService {
             fandomDtoList.add(dto);
         }
         return  fandomDtoList;
+    }
+
+    public FandomResponseDto.FandomDto showOneFandomArticle(Long fandomId){
+        Fandom fandom = fandomRepository.findById(fandomId).orElseThrow(()-> new ErrorHandler(ErrorStatus._CANNOT_LOAD_FANDOM));
+        List<FandomImage> fandomImages = fandomImageRepository.findFandomImages(fandom.getId());
+        List<String> fandomImageUrlList = fandomImages.stream().map(FandomImage::getImage).collect(Collectors.toList());
+        Member member = fandom.getMember();
+        return FandomConverter.toFandomDto(fandom,fandomImageUrlList,member);
     }
 
 }


### PR DESCRIPTION
1
게시판별 팬덤(컬처,아나운스먼트) / 콘텐츠(이벤트,카드뉴스,비디오)/ 커뮤니티(ALL, 피드백) 전체 조회: 피그마 3페이지 a 구현완료

2
각각의 게시글 상세조회 구현 완료: 피그마 3페이지 d 구현완료