### PR TITLE
브랜드 내부 멤버 작성 글/댓글 조회 기능 리팩토링

### DIFF
--- a/src/main/java/com/brandol/config/SecurityConfig.java
+++ b/src/main/java/com/brandol/config/SecurityConfig.java
@@ -28,7 +28,6 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring().antMatchers(
-                "/**",
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
                 "/swagger-resources/**",

--- a/src/main/java/com/brandol/config/SecurityConfig.java
+++ b/src/main/java/com/brandol/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring().antMatchers(
+                "/**",
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
                 "/swagger-resources/**",

--- a/src/main/java/com/brandol/controller/BrandController.java
+++ b/src/main/java/com/brandol/controller/BrandController.java
@@ -5,11 +5,12 @@ import com.brandol.apiPayload.code.status.SuccessStatus;
 import com.brandol.domain.Brand;
 import com.brandol.dto.request.BrandRequestDto;
 import com.brandol.dto.response.BrandResponseDto;
+import com.brandol.dto.response.MemberResponseDto;
 import com.brandol.service.BrandService;
+import com.brandol.service.MemberService;
 import com.brandol.validation.annotation.ExistBrand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class BrandController {
 
     private final BrandService brandService;
+    private final MemberService memberService;
 
 
     @Operation(summary = "브랜드 생성",description ="브랜돌 서비스에 브랜드를 신규 등록하는 함수",hidden = false ) // 테스트 해야함
@@ -60,6 +62,20 @@ public class BrandController {
     public ApiResponse<BrandResponseDto.BrandCommunityDto> showBrandCommunity(@ExistBrand @PathVariable("brandId")Long brandId){
         BrandResponseDto.BrandCommunityDto brandCommunityDto = brandService.makeCommunityBody(brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(),SuccessStatus._OK.getMessage(), brandCommunityDto);
+    }
+
+    @Operation(summary = "멤버 작성 글 조회",description ="2페이지 d 진입시 호출하는 API" )
+    @GetMapping("/brands/{brandId}/my-written/articles")
+    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenArticle(@PathVariable("brandId")Long brandId,@RequestParam("memberId")Long memberId){
+        MemberResponseDto.MemberWrittenMainDto dto = memberService.makeBrandMemberWrittenPage(memberId,brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
+    }
+
+    @Operation(summary = "멤버 작성 댓글 조회",description ="2페이지 d 진입시 호출하는 API" )
+    @GetMapping("/brands/{brandId}/my-written/comments")
+    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenComment(@PathVariable("brandId")Long brandId,@RequestParam("memberId")Long memberId){
+        MemberResponseDto.MemberWrittenMainDto dto = memberService.makeBrandMemberWrittenCommentPage(memberId,brandId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
     }
 
     @Operation(summary = "브랜드 커뮤니티 게시글 생성",description = "브랜드 콘텐츠에 종속된 브랜드 자유게시판, 피드백 게시판에 게시글 생성")

--- a/src/main/java/com/brandol/controller/CommentController.java
+++ b/src/main/java/com/brandol/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.brandol.controller;
 import com.brandol.apiPayload.ApiResponse;
 import com.brandol.apiPayload.code.status.SuccessStatus;
 import com.brandol.dto.request.CommentRequestDto;
+import com.brandol.dto.response.CommentResponseDto;
 import com.brandol.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.method.P;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -66,5 +69,12 @@ public class CommentController {
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"CommunityCommentId: "+ nestedCommentId);
     }
 
+    @Operation(summary = "팬덤 게시글 댓글 전체 조회",description ="해당 팬덤 게시글의 댓글 전체 조회" )
+    @Parameter(name = "fandomId",description = "대상 팬덤게시글의 id")
+    @GetMapping("fandom/{fandomId}/comments")
+    public ApiResponse<List<CommentResponseDto.CommentPackageDto>> showAllFandomComments(@PathVariable("fandomId")Long fandomId){
+        List<CommentResponseDto.CommentPackageDto> dto = commentService.showAllFandomComment(fandomId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
+    }
 
 }

--- a/src/main/java/com/brandol/controller/CommentController.java
+++ b/src/main/java/com/brandol/controller/CommentController.java
@@ -71,10 +71,27 @@ public class CommentController {
 
     @Operation(summary = "팬덤 게시글 댓글 전체 조회",description ="해당 팬덤 게시글의 댓글 전체 조회" )
     @Parameter(name = "fandomId",description = "대상 팬덤게시글의 id")
-    @GetMapping("fandom/{fandomId}/comments")
+    @GetMapping("fandoms/{fandomId}/comments/all")
     public ApiResponse<List<CommentResponseDto.CommentPackageDto>> showAllFandomComments(@PathVariable("fandomId")Long fandomId){
         List<CommentResponseDto.CommentPackageDto> dto = commentService.showAllFandomComment(fandomId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
     }
+
+    @Operation(summary = "콘텐츠 게시글 댓글 전체 조회",description ="해당 콘텐츠 게시글의 댓글 전체 조회" )
+    @Parameter(name = "contentsId",description = "대상 콘텐츠 게시글의 id")
+    @GetMapping("contents/{contentsId}/comments/all")
+    public ApiResponse<List<CommentResponseDto.CommentPackageDto>> showAllContentsComments(@PathVariable("contentsId")Long contentsId){
+        List<CommentResponseDto.CommentPackageDto> dto = commentService.showAllContentsComment(contentsId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
+    }
+
+    @Operation(summary = "커뮤니티 게시글 댓글 전체 조회",description ="해당 커뮤니티 게시글의 댓글 전체 조회" )
+    @Parameter(name = "communityId",description = "대상 커뮤니티 게시글의 id")
+    @GetMapping("communities/{communityId}/comments/all")
+    public ApiResponse<List<CommentResponseDto.CommentPackageDto>> showAllCommunityComments(@PathVariable("communityId")Long communityId){
+        List<CommentResponseDto.CommentPackageDto> dto = commentService.showAllCommunityComment(communityId);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
+    }
+
 
 }

--- a/src/main/java/com/brandol/controller/MemberController.java
+++ b/src/main/java/com/brandol/controller/MemberController.java
@@ -30,6 +30,7 @@ public class MemberController {
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), memberMainDto);
     }
 
+    /*
     @Operation(summary = "멤버 작성 글조회",description ="2페이지 d 진입시 호출하는 API" )
     @GetMapping("/user/my/written/articles")
     public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenArticle(@RequestParam("memberId")Long meberId){
@@ -37,13 +38,16 @@ public class MemberController {
          return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
     }
 
+     */
+
+    /*
     @Operation(summary = "멤버 작성 댓글 조회",description ="2페이지 d 진입시 호출하는 API" )
     @GetMapping("/user/my/written/comments")
-    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenComment(@RequestParam("memberId")Long meberId){
-        MemberResponseDto.MemberWrittenMainDto dto = memberService.makeMemberWrittenCommentPage(meberId);
+    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenComment(@RequestParam("memberId")Long memberId){
+        MemberResponseDto.MemberWrittenMainDto dto = memberService.makeMemberWrittenCommentPage(memberId,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
     }
 
-
+     */
 
 }

--- a/src/main/java/com/brandol/controller/MemberController.java
+++ b/src/main/java/com/brandol/controller/MemberController.java
@@ -35,5 +35,4 @@ public class MemberController {
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), memberAvatarDto);
     }
 
-
 }

--- a/src/main/java/com/brandol/controller/MemberController.java
+++ b/src/main/java/com/brandol/controller/MemberController.java
@@ -10,10 +10,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 @RestController
 @RequiredArgsConstructor
 @Validated
@@ -28,20 +26,6 @@ public class MemberController {
         Long memberId = Long.parseLong(authentication.getName());
         MemberResponseDto.MemberMainDto memberMainDto = memberService.makeMemberMain(memberId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), memberMainDto);
-    }
-
-    @Operation(summary = "멤버 작성 글조회",description ="2페이지 d 진입시 호출하는 API" )
-    @GetMapping("/user/my/written/articles")
-    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenArticle(@RequestParam("memberId")Long meberId){
-         MemberResponseDto.MemberWrittenMainDto dto = memberService.makeMemberWrittenPage(meberId);
-         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
-    }
-
-    @Operation(summary = "멤버 작성 댓글 조회",description ="2페이지 d 진입시 호출하는 API" )
-    @GetMapping("/user/my/written/comments")
-    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenComment(@RequestParam("memberId")Long meberId){
-        MemberResponseDto.MemberWrittenMainDto dto = memberService.makeMemberWrittenCommentPage(meberId);
-        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
     }
 
     @Operation(summary = "타 멤버의 아바타 및 닉네임 조회")

--- a/src/main/java/com/brandol/controller/MemberController.java
+++ b/src/main/java/com/brandol/controller/MemberController.java
@@ -30,7 +30,6 @@ public class MemberController {
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), memberMainDto);
     }
 
-    /*
     @Operation(summary = "멤버 작성 글조회",description ="2페이지 d 진입시 호출하는 API" )
     @GetMapping("/user/my/written/articles")
     public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenArticle(@RequestParam("memberId")Long meberId){
@@ -38,13 +37,10 @@ public class MemberController {
          return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
     }
 
-     */
-
-    /*
     @Operation(summary = "멤버 작성 댓글 조회",description ="2페이지 d 진입시 호출하는 API" )
     @GetMapping("/user/my/written/comments")
-    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenComment(@RequestParam("memberId")Long memberId){
-        MemberResponseDto.MemberWrittenMainDto dto = memberService.makeMemberWrittenCommentPage(memberId,brandId);
+    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenComment(@RequestParam("memberId")Long meberId){
+        MemberResponseDto.MemberWrittenMainDto dto = memberService.makeMemberWrittenCommentPage(meberId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
     }
 

--- a/src/main/java/com/brandol/converter/CommentConverter.java
+++ b/src/main/java/com/brandol/converter/CommentConverter.java
@@ -3,6 +3,8 @@ package com.brandol.converter;
 
 import com.brandol.domain.Fandom;
 import com.brandol.domain.Member;
+import com.brandol.domain.mapping.CommunityComment;
+import com.brandol.domain.mapping.ContentsComment;
 import com.brandol.domain.mapping.FandomComment;
 import com.brandol.dto.request.CommentRequestDto;
 import com.brandol.dto.response.CommentResponseDto;
@@ -44,11 +46,65 @@ public class CommentConverter {
                 .build();
     }
 
-    public static CommentResponseDto.CommentPackageDto toCommentPackageDto(FandomComment parent, List<FandomComment> childComments){
+    public static CommentResponseDto.CommentDto toContentsCommentDto(ContentsComment contentsComment, Member member){
+        return CommentResponseDto.CommentDto.builder()
+                .commentId(contentsComment.getId())
+                .parentId(contentsComment.getParentId())
+                .depth(contentsComment.getDepth())
+                .writerId(member.getId())
+                .writerName(member.getName())
+                .writerProfile(member.getAvatar())
+                .content(contentsComment.getContent())
+                .likeCount(0)
+                .writtenDate(contentsComment.getCreatedAt())
+                .build();
+    }
+
+    public static CommentResponseDto.CommentPackageDto toFandomCommentPackageDto(FandomComment parent, List<FandomComment> childComments){
         CommentResponseDto.CommentDto parentDto = toFandomCommentDto(parent,parent.getWriter());
         List<CommentResponseDto.CommentDto> childDtos = new ArrayList<>();
         for(int i=0; i<childComments.size();i++){
             CommentResponseDto.CommentDto childDto = toFandomCommentDto(childComments.get(i),childComments.get(i).getWriter());
+            childDtos.add(childDto);
+        }
+        return CommentResponseDto.CommentPackageDto.builder()
+                .parentDto(parentDto)
+                .childDtoList(childDtos)
+                .build();
+    }
+
+    public static CommentResponseDto.CommentPackageDto toContentsCommentPackageDto(ContentsComment parent, List<ContentsComment> childComments){
+        CommentResponseDto.CommentDto parentDto = toContentsCommentDto(parent,parent.getWriter());
+        List<CommentResponseDto.CommentDto> childDtos = new ArrayList<>();
+        for(int i=0; i<childComments.size();i++){
+            CommentResponseDto.CommentDto childDto = toContentsCommentDto(childComments.get(i),childComments.get(i).getWriter());
+            childDtos.add(childDto);
+        }
+        return CommentResponseDto.CommentPackageDto.builder()
+                .parentDto(parentDto)
+                .childDtoList(childDtos)
+                .build();
+    }
+
+    public static CommentResponseDto.CommentDto toCommunityCommentDto(CommunityComment communityComment, Member member){
+        return CommentResponseDto.CommentDto.builder()
+                .commentId(communityComment.getId())
+                .parentId(communityComment.getParentId())
+                .depth(communityComment.getDepth())
+                .writerId(member.getId())
+                .writerName(member.getName())
+                .writerProfile(member.getAvatar())
+                .content(communityComment.getContent())
+                .likeCount(0)
+                .writtenDate(communityComment.getCreatedAt())
+                .build();
+    }
+
+    public static CommentResponseDto.CommentPackageDto toCommunityCommentPackageDto(CommunityComment parent, List<CommunityComment> childComments){
+        CommentResponseDto.CommentDto parentDto = toCommunityCommentDto(parent,parent.getWriter());
+        List<CommentResponseDto.CommentDto> childDtos = new ArrayList<>();
+        for(int i=0; i<childComments.size();i++){
+            CommentResponseDto.CommentDto childDto = toCommunityCommentDto(childComments.get(i),childComments.get(i).getWriter());
             childDtos.add(childDto);
         }
         return CommentResponseDto.CommentPackageDto.builder()

--- a/src/main/java/com/brandol/converter/CommentConverter.java
+++ b/src/main/java/com/brandol/converter/CommentConverter.java
@@ -5,9 +5,13 @@ import com.brandol.domain.Fandom;
 import com.brandol.domain.Member;
 import com.brandol.domain.mapping.FandomComment;
 import com.brandol.dto.request.CommentRequestDto;
+import com.brandol.dto.response.CommentResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -23,6 +27,33 @@ public class CommentConverter {
                 .isDeleted(false)
                 .writer(member)
                 .fandom(fandom)
+                .build();
+    }
+
+    public static CommentResponseDto.CommentDto toFandomCommentDto(FandomComment fandomComment, Member member){
+        return CommentResponseDto.CommentDto.builder()
+                .commentId(fandomComment.getId())
+                .parentId(fandomComment.getParentId())
+                .depth(fandomComment.getDepth())
+                .writerId(member.getId())
+                .writerName(member.getName())
+                .writerProfile(member.getAvatar())
+                .content(fandomComment.getContent())
+                .likeCount(0)
+                .writtenDate(fandomComment.getCreatedAt())
+                .build();
+    }
+
+    public static CommentResponseDto.CommentPackageDto toCommentPackageDto(FandomComment parent, List<FandomComment> childComments){
+        CommentResponseDto.CommentDto parentDto = toFandomCommentDto(parent,parent.getWriter());
+        List<CommentResponseDto.CommentDto> childDtos = new ArrayList<>();
+        for(int i=0; i<childComments.size();i++){
+            CommentResponseDto.CommentDto childDto = toFandomCommentDto(childComments.get(i),childComments.get(i).getWriter());
+            childDtos.add(childDto);
+        }
+        return CommentResponseDto.CommentPackageDto.builder()
+                .parentDto(parentDto)
+                .childDtoList(childDtos)
                 .build();
     }
 }

--- a/src/main/java/com/brandol/converter/MemberConverter.java
+++ b/src/main/java/com/brandol/converter/MemberConverter.java
@@ -81,6 +81,7 @@ public class MemberConverter {
     }
 
     public static MemberResponseDto.MemberAvatarDto toMemberAvatarDto(Member member){
+
         return MemberResponseDto.MemberAvatarDto.builder()
                 .memberId(member.getId())
                 .avatar(member.getAvatar())

--- a/src/main/java/com/brandol/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/CommentResponseDto.java
@@ -26,7 +26,6 @@ public class CommentResponseDto {
         public Long commentId;
         public Long parentId;
         public Long depth;
-        public Long articleId;
         public Long writerId;
         public String writerName;
         public String writerProfile;

--- a/src/main/java/com/brandol/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/CommentResponseDto.java
@@ -1,0 +1,37 @@
+package com.brandol.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CommentResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class CommentPackageDto{
+
+        public CommentDto parentDto;
+        public List<CommentDto> childDtoList;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class CommentDto{
+
+        public Long commentId;
+        public Long parentId;
+        public Long depth;
+        public Long articleId;
+        public Long writerId;
+        public String writerName;
+        public String writerProfile;
+        public String content;
+        private int likeCount;
+        public LocalDateTime writtenDate;
+    }
+}

--- a/src/main/java/com/brandol/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/MemberResponseDto.java
@@ -56,8 +56,7 @@ public class MemberResponseDto {
         private Long writerId;
         private String writerName;
         private String writerProfile;
-        private String articleType;
-        private Long id;
+        private String articleInfo;
         private String title;
         private String content;
         private List<String> images;

--- a/src/main/java/com/brandol/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/MemberResponseDto.java
@@ -77,7 +77,7 @@ public class MemberResponseDto {
 
     @Builder
     @Getter
-    @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED) // 빨간줄 떠서 내가 수정함 Required -> No by 종.
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     public static class MemberAvatarDto {
         private Long memberId;

--- a/src/main/java/com/brandol/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/brandol/repository/CommunityCommentRepository.java
@@ -14,4 +14,7 @@ public interface CommunityCommentRepository extends JpaRepository<CommunityComme
     @Query("select cc from CommunityComment cc where  cc.parentId = :parentId order by cc.createdAt desc")
     List<CommunityComment> findCommunityCommentsByParentId(@Param("parentId")Long parentId);
 
+    @Query("select cc from CommunityComment cc where  cc.community.id = :communityId order by  cc.createdAt asc")
+    List<CommunityComment> findAllByCommunityId(@Param("communityId")Long CommunityId);
+
 }

--- a/src/main/java/com/brandol/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/brandol/repository/CommunityCommentRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment,Long>{
-    @Query("select cc from CommunityComment cc where cc.writer.id = :memberId")
-    List<CommunityComment> findCommunityCommentByMemberId(@Param("memberId") Long memberId);
+    @Query("select cc from CommunityComment cc where cc.writer.id = :memberId and cc.community.brand.id = :brandId")
+    List<CommunityComment> findCommunityCommentByMemberIdAndBrandId(@Param("memberId") Long memberId,@Param("brandId")Long brandId);
 
     @Query("select cc from CommunityComment cc where  cc.parentId = :parentId order by cc.createdAt desc")
     List<CommunityComment> findCommunityCommentsByParentId(@Param("parentId")Long parentId);

--- a/src/main/java/com/brandol/repository/ContentsCommentRepository.java
+++ b/src/main/java/com/brandol/repository/ContentsCommentRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ContentsCommentRepository extends JpaRepository<ContentsComment,Long> {
-    @Query("select cc from ContentsComment cc where cc.writer.id = :memberId")
-    List<ContentsComment> findContentsCommentByMemberId(@Param("memberId")Long memberId);
+    @Query("select cc from ContentsComment cc where cc.writer.id = :memberId and cc.contents.brand.id = :brandId")
+    List<ContentsComment> findContentsCommentByMemberIdAndBrandId(@Param("memberId")Long memberId,@Param("brandId")Long brandId);
 
     @Query("select cc from ContentsComment cc where cc.parentId = :parentId order by cc.createdAt")
     List<ContentsComment> findContentsCommentsByParentId(@Param("parentId")Long parentId);

--- a/src/main/java/com/brandol/repository/ContentsCommentRepository.java
+++ b/src/main/java/com/brandol/repository/ContentsCommentRepository.java
@@ -13,4 +13,7 @@ public interface ContentsCommentRepository extends JpaRepository<ContentsComment
 
     @Query("select cc from ContentsComment cc where cc.parentId = :parentId order by cc.createdAt")
     List<ContentsComment> findContentsCommentsByParentId(@Param("parentId")Long parentId);
+
+    @Query("select cc from ContentsComment cc where cc.contents.id = :contentsId order by cc.createdAt asc ")
+    List<ContentsComment> findAllByContentsId(@Param("contentsId")Long contentsId);
 }

--- a/src/main/java/com/brandol/repository/FandomCommentRepository.java
+++ b/src/main/java/com/brandol/repository/FandomCommentRepository.java
@@ -9,8 +9,8 @@ import java.util.List;
 
 public interface FandomCommentRepository extends JpaRepository<FandomComment,Long> {
 
-    @Query("select fc from FandomComment fc where fc.writer.id = :memberId")
-    List<FandomComment> findFandomCommentsByMemberId(@Param("memberId")Long memberId);
+    @Query("select fc from FandomComment fc where fc.writer.id = :memberId and fc.fandom.brand.id = :brandId")
+    List<FandomComment> findFandomCommentsByMemberIdAndBrandId(@Param("memberId")Long memberId,@Param("brandId")Long brandId);
 
     @Query("select fc from FandomComment fc where fc.parentId = :parentId order by fc.createdAt desc ")
     List<FandomComment> findFandomCommentsByParentId(@Param("parentId")Long parentId);

--- a/src/main/java/com/brandol/repository/FandomCommentRepository.java
+++ b/src/main/java/com/brandol/repository/FandomCommentRepository.java
@@ -14,4 +14,7 @@ public interface FandomCommentRepository extends JpaRepository<FandomComment,Lon
 
     @Query("select fc from FandomComment fc where fc.parentId = :parentId order by fc.createdAt desc ")
     List<FandomComment> findFandomCommentsByParentId(@Param("parentId")Long parentId);
+
+    @Query("select fc from FandomComment fc where fc.fandom.id = :fandomId order by fc.createdAt asc ")
+    List<FandomComment> findAllByFandomId(@Param("fandomId")Long fandomId);
 }

--- a/src/main/java/com/brandol/service/CommentService.java
+++ b/src/main/java/com/brandol/service/CommentService.java
@@ -172,10 +172,54 @@ public class CommentService {
         List<CommentResponseDto.CommentPackageDto> results = new ArrayList<>();
         for(int i=0; i<parentCommentList.size();i++){
             Long parentId = parentCommentList.get(i).getParentId();
-           CommentResponseDto.CommentPackageDto dto = CommentConverter.toCommentPackageDto(parentCommentList.get(i),parentChildPairMap.get(parentId));
+           CommentResponseDto.CommentPackageDto dto = CommentConverter.toFandomCommentPackageDto(parentCommentList.get(i),parentChildPairMap.get(parentId));
            results.add(dto);
         }
 
+        return results;
+    }
+
+    public List<CommentResponseDto.CommentPackageDto> showAllContentsComment(Long contentsId){
+
+        List<ContentsComment> contentsCommentList = contentsCommentRepository.findAllByContentsId(contentsId);
+        List<ContentsComment> parentCommentList = contentsCommentList.stream().filter(cc-> cc.getDepth() == 0).collect(Collectors.toList()); //부모 댓글
+        List<ContentsComment> childCommentList = contentsCommentList.stream().filter(cc->cc.getDepth() == 1).collect(Collectors.toList()); // 자식 댓글
+
+        Map<Long,List<ContentsComment>> parentChildPairMap = new LinkedHashMap<>();
+
+        for(int i=0; i<contentsCommentList.size();i++){
+            Long key = contentsCommentList.get(i).getId();
+            parentChildPairMap.put(key,childCommentList.stream().filter(cc->cc.getParentId() == key).collect(Collectors.toList()));
+        }
+
+        List<CommentResponseDto.CommentPackageDto> results = new ArrayList<>();
+        for(int i=0; i<parentCommentList.size();i++){
+            Long parentId = parentCommentList.get(i).getParentId();
+            CommentResponseDto.CommentPackageDto dto = CommentConverter.toContentsCommentPackageDto(parentCommentList.get(i),parentChildPairMap.get(parentId));
+            results.add(dto);
+        }
+        return results;
+    }
+
+    public List<CommentResponseDto.CommentPackageDto> showAllCommunityComment(Long communityId){
+
+        List<CommunityComment> communityCommentList = communityCommentRepository.findAllByCommunityId(communityId);
+        List<CommunityComment> parentCommentList = communityCommentList.stream().filter(cc-> cc.getDepth() == 0).collect(Collectors.toList()); //부모 댓글
+        List<CommunityComment> childCommentList = communityCommentList.stream().filter(cc->cc.getDepth() == 1).collect(Collectors.toList()); // 자식 댓글
+
+        Map<Long,List<CommunityComment>> parentChildPairMap = new LinkedHashMap<>();
+
+        for(int i=0; i<communityCommentList.size();i++){
+            Long key = communityCommentList.get(i).getId();
+            parentChildPairMap.put(key,childCommentList.stream().filter(cc->cc.getParentId() == key).collect(Collectors.toList()));
+        }
+
+        List<CommentResponseDto.CommentPackageDto> results = new ArrayList<>();
+        for(int i=0; i<parentCommentList.size();i++){
+            Long parentId = parentCommentList.get(i).getParentId();
+            CommentResponseDto.CommentPackageDto dto = CommentConverter.toCommunityCommentPackageDto(parentCommentList.get(i),parentChildPairMap.get(parentId));
+            results.add(dto);
+        }
         return results;
     }
 }

--- a/src/main/java/com/brandol/service/CommentService.java
+++ b/src/main/java/com/brandol/service/CommentService.java
@@ -2,6 +2,7 @@ package com.brandol.service;
 
 import com.brandol.apiPayload.code.status.ErrorStatus;
 import com.brandol.apiPayload.exception.ErrorHandler;
+import com.brandol.converter.CommentConverter;
 import com.brandol.domain.Contents;
 import com.brandol.domain.Fandom;
 import com.brandol.domain.Member;
@@ -10,13 +11,14 @@ import com.brandol.domain.mapping.CommunityComment;
 import com.brandol.domain.mapping.ContentsComment;
 import com.brandol.domain.mapping.FandomComment;
 import com.brandol.dto.request.CommentRequestDto;
+import com.brandol.dto.response.CommentResponseDto;
 import com.brandol.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -152,5 +154,28 @@ public class CommentService {
         communityCommentRepository.save(communityComment);
         community.updateComments(community.getComments()+1); // 커뮤니티 게시물의 댓글 개수 업데이트 (더티체킹 활용)
         return communityComment.getId();
+    }
+
+    public List<CommentResponseDto.CommentPackageDto> showAllFandomComment(Long fandomId){
+
+        List<FandomComment> fandomCommentList= fandomCommentRepository.findAllByFandomId(fandomId); //해당 게시글의 전체 댓글 조회
+        List<FandomComment> parentCommentList = fandomCommentList.stream().filter(fc-> fc.getDepth() == 0).collect(Collectors.toList()); //부모 댓글
+        List<FandomComment> childCommentList = fandomCommentList.stream().filter(fc->fc.getDepth() == 1 ).collect(Collectors.toList()); //자식 댓글
+
+        Map<Long,List<FandomComment>> parentChildPairMap =new LinkedHashMap<>(); // key: 부모댓글, value: 자식댓글 리스트
+
+        for(int i=0 ; i<fandomCommentList.size();i++){
+            Long key = fandomCommentList.get(i).getId();
+            parentChildPairMap.put(key,childCommentList.stream().filter(fc ->fc.getParentId() == key).collect(Collectors.toList()));
+        }
+
+        List<CommentResponseDto.CommentPackageDto> results = new ArrayList<>();
+        for(int i=0; i<parentCommentList.size();i++){
+            Long parentId = parentCommentList.get(i).getParentId();
+           CommentResponseDto.CommentPackageDto dto = CommentConverter.toCommentPackageDto(parentCommentList.get(i),parentChildPairMap.get(parentId));
+           results.add(dto);
+        }
+
+        return results;
     }
 }

--- a/src/main/java/com/brandol/service/MemberService.java
+++ b/src/main/java/com/brandol/service/MemberService.java
@@ -9,7 +9,6 @@ import com.brandol.domain.mapping.*;
 import com.brandol.dto.response.MemberResponseDto;
 import com.brandol.repository.*;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -107,131 +106,59 @@ public class MemberService {
         return memberRepository.existsByNickname(value);
     }
 
-    public MemberResponseDto.MemberWrittenMainDto makeMemberWrittenPage(Long memberId){
+    public MemberResponseDto.MemberWrittenMainDto makeBrandMemberWrittenPage(Long memberId, Long brandId){
 
         Member member = memberRepository.findOneById(memberId);
 
-        //특정 멤버가 작성한 팬덤 게시글을 조회해서 createdAt을 기준으로 내림차순 정렬 -> top 2개 추출
-        List<Fandom> fandomListWrittenByMember = member.getFandomList().stream().sorted(Comparator.comparing(Fandom::getCreatedAt)).collect(Collectors.toList());
-        int fandomSize = fandomListWrittenByMember.size();
-        List<Fandom> recentFandomListWrittenByMember = fandomListWrittenByMember.stream().limit(2).collect(Collectors.toList());
-
-        //특정 멤버가 작성한 콘텐츠를 조회해서 createdAt을 기준으로 내림차순 정렬 -> top 2개 추출
-        List<Contents> contentsListWrittenByMember = member.getContentsList().stream().sorted(Comparator.comparing(Contents::getCreatedAt)).collect(Collectors.toList());
-        int contentsSize = contentsListWrittenByMember.size();
-        List<Contents> recentContentsListWrittenByMember = contentsListWrittenByMember.stream().limit(2).collect(Collectors.toList());
-
-        //특정 멤버가 작성한 커뮤니티를 조회해서 createdAt을 기준으로 내림차순 정렬 -> top 2개 추출
-        List<Community> communityListWrittenByMember = member.getCommunityList().stream().sorted(Comparator.comparing(Community::getCreatedAt)).collect(Collectors.toList());
+        //특정 멤버가 작성한 특정 브랜드의 커뮤니티를 조회해서 createdAt을 기준으로 내림차순 정렬 -> top 2개 추출
+        List<Community> communityListWrittenByMember = member.getCommunityList().stream().filter(c->c.getBrand().getId() == brandId).sorted(Comparator.comparing(Community::getCreatedAt).reversed()).collect(Collectors.toList());
         int communitySize = communityListWrittenByMember.size();
         List<Community> recentCommunityListWrittenByMember = communityListWrittenByMember.stream().limit(2).collect(Collectors.toList());
 
-        // 각 게시판 별 가장 최신 article 각 2개씩(최대) 가져와 합친 List
-        List<Object> masterList =new ArrayList<>();
-        masterList.addAll(recentFandomListWrittenByMember);
-        masterList.addAll(recentContentsListWrittenByMember);
-        masterList.addAll(recentCommunityListWrittenByMember);
-
-        // 각각의 article 들의 createdAt 필드를 기준으로 내림차순으로 정렬
-        Collections.sort(masterList, Comparator.comparing(this::getArticleCreatedAt).reversed());
-
-        // 가장 최신 두건의 article 들만 추출
-        List<Object>resultArticleList = masterList.stream().limit(2).collect(Collectors.toList());
-
         List<MemberResponseDto.MemberWrittenDto> memberWrittenDtoList = new ArrayList<>();
-        for(int i=0;i<resultArticleList.size();i++){
 
-            //해당 객체가 Fandom 게시글 일 경우
-            if(resultArticleList.get(i) instanceof Fandom){
-                Fandom targetFandom = (Fandom) resultArticleList.get(i);
-                List<FandomImage> fandomImages = fandomImageRepository.findFandomImages(targetFandom.getId());
-                List<String>imageUrlList = fandomImages.stream().map(FandomImage::getImage).collect(Collectors.toList());
-                MemberResponseDto.MemberWrittenDto fandomArticle = MemberResponseDto.MemberWrittenDto.builder()
-                        .writerId(targetFandom.getMember().getId())
-                        .writerName(targetFandom.getMember().getNickname())
-                        .writerProfile(targetFandom.getMember().getAvatar())
-                        .articleType("Fandom")
-                        .id(targetFandom.getId())
-                        .title(targetFandom.getTitle())
-                        .content(targetFandom.getContent())
-                        .images(imageUrlList)
-                        .likeCount(targetFandom.getLikes())
-                        .commentCount(targetFandom.getComments())
-                        .writtenDate(targetFandom.getCreatedAt())
-                        .build();
-                memberWrittenDtoList.add(fandomArticle);
-
-            }
-
-            // 해당 객체가 콘텐츠 게시글 일 경우
-            else if(resultArticleList.get(i) instanceof Contents){
-                System.out.println(((Contents) resultArticleList.get(i)).getTitle());
-                Contents targetContents = (Contents) resultArticleList.get(i);
-                List<ContentsImage> contentsImages = contentImageRepository.findAllByContentsId(targetContents.getId());
-                List<String>imageUrlList = contentsImages.stream().map(ContentsImage::getImage).collect(Collectors.toList());
-                MemberResponseDto.MemberWrittenDto contentsArticle = MemberResponseDto.MemberWrittenDto.builder()
-                        .writerId(targetContents.getMember().getId())
-                        .writerName(targetContents.getMember().getNickname())
-                        .writerProfile(targetContents.getMember().getAvatar())
-                        .articleType("Contents")
-                        .id(targetContents.getId())
-                        .title(targetContents.getTitle())
-                        .content(targetContents.getContent())
-                        .images(imageUrlList)
-                        .likeCount(targetContents.getLikes())
-                        .commentCount(targetContents.getComments())
-                        .writtenDate(targetContents.getCreatedAt())
-                        .build();
-                memberWrittenDtoList.add(contentsArticle);
-            }
-
-            // 해당 게시글이 커뮤니티 게시글일 경우
-            else if(resultArticleList.get(i) instanceof Community){
-                System.out.println(((Community) resultArticleList.get(i)).getTitle());
-                Community targetCommunity = (Community)resultArticleList.get(i);
-                List<CommunityImage> communityImages = communityImageRepository.findAllByCommunityId(targetCommunity.getId());
-                List<String>imageUrlList = communityImages.stream().map(CommunityImage::getImage).collect(Collectors.toList());
-                MemberResponseDto.MemberWrittenDto communityArticle = MemberResponseDto.MemberWrittenDto.builder()
-                        .writerId(targetCommunity.getMember().getId())
-                        .writerName(targetCommunity.getMember().getNickname())
-                        .writerProfile(targetCommunity.getMember().getAvatar())
-                        .articleType("Community")
-                        .id(targetCommunity.getId())
-                        .title(targetCommunity.getTitle())
-                        .content(targetCommunity.getContent())
-                        .images(imageUrlList)
-                        .likeCount(targetCommunity.getLikes())
-                        .commentCount(targetCommunity.getComments())
-                        .writtenDate(targetCommunity.getCreatedAt())
-                        .build();
-                memberWrittenDtoList.add(communityArticle);
-            }
+        for(int i=0;i< recentCommunityListWrittenByMember.size();i++){
+            Community targetCommunity = recentCommunityListWrittenByMember.get(i);
+            List<CommunityImage> communityImages = communityImageRepository.findAllByCommunityId(targetCommunity.getId());
+            List<String>imageUrlList = communityImages.stream().map(CommunityImage::getImage).collect(Collectors.toList());
+            MemberResponseDto.MemberWrittenDto communityArticle = MemberResponseDto.MemberWrittenDto.builder()
+                    .writerId(targetCommunity.getMember().getId())
+                    .writerName(targetCommunity.getMember().getNickname())
+                    .writerProfile(targetCommunity.getMember().getAvatar())
+                    .articleInfo("Community:"+targetCommunity.getId())
+                    .title(targetCommunity.getTitle())
+                    .content(targetCommunity.getContent())
+                    .images(imageUrlList)
+                    .likeCount(targetCommunity.getLikes())
+                    .commentCount(targetCommunity.getComments())
+                    .writtenDate(targetCommunity.getCreatedAt())
+                    .build();
+            memberWrittenDtoList.add(communityArticle);
         }
-        Integer totalArticleCount = fandomSize + contentsSize + communitySize;
-        return MemberConverter.toMemberWrittenMainDto(totalArticleCount, memberWrittenDtoList);
+
+        return MemberConverter.toMemberWrittenMainDto(communitySize, memberWrittenDtoList);
     }
 
-    public MemberResponseDto.MemberWrittenMainDto makeMemberWrittenCommentPage(Long memberId){
+    public MemberResponseDto.MemberWrittenMainDto makeBrandMemberWrittenCommentPage(Long memberId, Long brandId){
 
-        List<FandomComment> fandomCommentList = fandomCommentRepository.findFandomCommentsByMemberId(memberId);
+        List<FandomComment> fandomCommentList = fandomCommentRepository.findFandomCommentsByMemberIdAndBrandId(memberId,brandId); //해당 브랜드에 해당 멤버가 작성한 댓글 리스트
         Integer fandomCommentCount = fandomCommentList.size();
-        List<ContentsComment> contentsCommentList = contentsCommentRepository.findContentsCommentByMemberId(memberId);
+        List<ContentsComment> contentsCommentList = contentsCommentRepository.findContentsCommentByMemberIdAndBrandId(memberId,brandId); //해당 브랜드에 해당 멤버가 작성한 댓글 리스트
         Integer contentsCommentCount = contentsCommentList.size();
-        List<CommunityComment> communityCommentList = communityCommentRepository.findCommunityCommentByMemberId(memberId);
+        List<CommunityComment> communityCommentList = communityCommentRepository.findCommunityCommentByMemberIdAndBrandId(memberId,brandId); //해당 브랜드에 해당 멤버가 작성한 댓글 리스트
         Integer communityCommentCount = communityCommentList.size();
 
-        List<Object> masterList = new ArrayList<>();
+        List<Object> masterList = new ArrayList<>(); // 댓글 리스트 합치기
         masterList.addAll(fandomCommentList);
         masterList.addAll(contentsCommentList);
         masterList.addAll(communityCommentList);
 
-        Collections.sort(masterList, Comparator.comparing(this::getCommentCreatedAt).reversed());
-        List<Object>resultArticleList = masterList.stream().limit(2).collect(Collectors.toList());
-        List<MemberResponseDto.MemberWrittenDto> memberWrittenCommentDtoList = new ArrayList<>();
+        Collections.sort(masterList, Comparator.comparing(this::getCommentCreatedAt).reversed()); // 댓글 리스트에서 시간 내림차순 정렬
+        List<MemberResponseDto.MemberWrittenDto> memberWrittenCommentDtoList = new ArrayList<>(); // dto 리턴 리스트
 
-        for(int i=0; i<resultArticleList.size();i++){
-            if(resultArticleList.get(i) instanceof FandomComment){
-                FandomComment targetFandomComment = (FandomComment) resultArticleList.get(i);
+        for(int i=0; i<masterList.size();i++){
+            if(masterList.get(i) instanceof FandomComment){
+                FandomComment targetFandomComment = (FandomComment) masterList.get(i);
                 Fandom targetFandom = targetFandomComment.getFandom();
                 List<FandomImage> fandomImageList = fandomImageRepository.findFandomImages(targetFandom.getId());
                 List<String> imageUrlList = fandomImageList.stream().map(FandomImage::getImage).collect(Collectors.toList());
@@ -240,8 +167,7 @@ public class MemberService {
                         .writerId(targetFandom.getMember().getId())
                         .writerName(targetFandom.getMember().getName())
                         .writerProfile(targetFandom.getMember().getAvatar())
-                        .articleType("Fandom")
-                        .id(targetFandom.getId())
+                        .articleInfo("Fandom:"+targetFandom.getId())
                         .title(targetFandom.getTitle())
                         .images(imageUrlList)
                         .likeCount(targetFandom.getLikes())
@@ -249,8 +175,8 @@ public class MemberService {
                         .writtenDate(targetFandom.getCreatedAt())
                         .build();
                 memberWrittenCommentDtoList.add(fandomArticle);
-            } else if (resultArticleList.get(i) instanceof ContentsComment) {
-                ContentsComment targetContentsComment = (ContentsComment) resultArticleList.get(i);
+            } else if (masterList.get(i) instanceof ContentsComment) {
+                ContentsComment targetContentsComment = (ContentsComment) masterList.get(i);
                 Contents targetContents = targetContentsComment.getContents();
                 List<ContentsImage> contentsImageList = contentImageRepository.findAllByContentsId(targetContentsComment.getId());
                 List<String> imageUrlList = contentsImageList.stream().map(ContentsImage::getImage).collect(Collectors.toList());
@@ -259,8 +185,7 @@ public class MemberService {
                         .writerId(targetContents.getMember().getId())
                         .writerName(targetContents.getMember().getName())
                         .writerProfile(targetContents.getMember().getAvatar())
-                        .articleType("Contents")
-                        .id(targetContents.getId())
+                        .articleInfo("Contents:"+targetContents.getId())
                         .title(targetContents.getTitle())
                         .images(imageUrlList)
                         .likeCount(targetContents.getLikes())
@@ -269,8 +194,8 @@ public class MemberService {
                         .build();
                 memberWrittenCommentDtoList.add(contentsArticle);
 
-            } else if (resultArticleList.get(i) instanceof  CommunityComment) {
-                CommunityComment targetCommunityComment = (CommunityComment) resultArticleList.get(i);
+            } else if (masterList.get(i) instanceof  CommunityComment) {
+                CommunityComment targetCommunityComment = (CommunityComment) masterList.get(i);
                 Community tagetCommunity = targetCommunityComment.getCommunity();
                 List<CommunityImage> communityImageList = communityImageRepository.findAllByCommunityId(targetCommunityComment.getId());
                 List<String> imageUrlList = communityImageList.stream().map(CommunityImage::getImage).collect(Collectors.toList());
@@ -279,8 +204,7 @@ public class MemberService {
                         .writerId(tagetCommunity.getMember().getId())
                         .writerName(tagetCommunity.getMember().getName())
                         .writerProfile(tagetCommunity.getMember().getAvatar())
-                        .articleType("Community")
-                        .id(tagetCommunity.getId())
+                        .articleInfo("Community:"+tagetCommunity.getId())
                         .title(tagetCommunity.getTitle())
                         .images(imageUrlList)
                         .likeCount(tagetCommunity.getLikes())
@@ -291,24 +215,13 @@ public class MemberService {
                 memberWrittenCommentDtoList.add(communityArticle);
             }
         }
-
-        Integer commentCount = fandomCommentCount + contentsCommentCount + communityCommentCount;
-        return MemberConverter.toMemberWrittenMainDto(commentCount,memberWrittenCommentDtoList);
+        Set<MemberResponseDto.MemberWrittenDto> memberWrittenDtoSet = memberWrittenCommentDtoList.stream().collect(Collectors.toCollection(()->new TreeSet<>(Comparator.comparing(MemberResponseDto.MemberWrittenDto::getArticleInfo)))); //게시글 중복제거
+        List<MemberResponseDto.MemberWrittenDto> result = new ArrayList<>(memberWrittenDtoSet).stream().limit(2).collect(Collectors.toList()); //리스트 전환 (2건만 추출)
+        Collections.sort(result, Comparator.comparing(MemberResponseDto.MemberWrittenDto::getWrittenDate).reversed());// 시간순으로 정렬
+        Integer commentCount = fandomCommentCount + contentsCommentCount + communityCommentCount; //전체 댓글수 카운팅
+        return MemberConverter.toMemberWrittenMainDto(commentCount,result);
     }
 
-
-
-    private  LocalDateTime getArticleCreatedAt(Object entity) {
-        // 각 엔티티의 생성 날짜를 가져오는 메서드
-        if (entity instanceof Fandom) {
-            return ((Fandom) entity).getCreatedAt();
-        } else if (entity instanceof Contents) {
-            return ((Contents) entity).getCreatedAt();
-        } else if (entity instanceof Community) {
-            return ((Community) entity).getCreatedAt();
-        }
-        return null;
-    }
 
     private LocalDateTime getCommentCreatedAt(Object entity) {
         // 각 엔티티의 생성 날짜를 가져오는 메서드


### PR DESCRIPTION
1. 글 조회: 브랜드 커뮤니티로 탐색 범위 축소
2. 댓글이 달려있는 게시글 조회: 브랜드의 모든 게시글로 탐색 범위 축소 + 한 게시글에 최신 댓글을 2개 다는 경우 같은 게시글이 불러와지는 문제 발생 ->  new TreeSet<>(Comparator.comparing(MemberResponseDto.MemberWrittenDto::getArticleInfo))));  로 해결

3.  브랜드 내 멤버 작성 글/댓글 조회 기능 컨트롤러 위치 변경 멤버 컨트롤러 -> 브랜드 컨트롤러