### PR TITLE
[Feat/75] 아이템 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/brandol/controller/ItemController.java
+++ b/src/main/java/com/brandol/controller/ItemController.java
@@ -40,7 +40,7 @@ public class ItemController {
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(), wearMyItem);
     }
 
-    @Operation(summary = "아이템 정보 조회",description = "구매한 아이템 목록 중 사용자가 선택한 아이템을 착용")
+    @Operation(summary = "아이템 정보 조회",description = "검색 페이지에서 특정 아이템 클릭 시, 피그마 기준 5페이지 d의 최상단에서 해당 아이템 정보 조회 ")
     @GetMapping("/items/{itemId}")
     public ApiResponse<ItemResponseDto.AvatarStoreBodyListDto> itemInfo(@PathVariable Long itemId, @RequestParam("itemPart")String itemPart) {
         ItemResponseDto.AvatarStoreBodyListDto itemDto = itemService.makeAvatarStoreBodyPage(itemId, itemPart);

--- a/src/main/java/com/brandol/controller/ItemController.java
+++ b/src/main/java/com/brandol/controller/ItemController.java
@@ -4,6 +4,7 @@ import com.brandol.apiPayload.ApiResponse;
 import com.brandol.apiPayload.code.status.SuccessStatus;
 import com.brandol.domain.mapping.MyItem;
 import com.brandol.dto.request.MyItemRequestDto;
+import com.brandol.dto.response.ItemResponseDto;
 import com.brandol.dto.response.MyItemResponseDto;
 import com.brandol.service.ItemService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,5 +38,12 @@ public class ItemController {
         Long memberId = Long.parseLong(authentication.getName());
         String wearMyItem = itemService.toWearMyItem(memberId, request);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(), wearMyItem);
+    }
+
+    @Operation(summary = "아이템 정보 조회",description = "구매한 아이템 목록 중 사용자가 선택한 아이템을 착용")
+    @GetMapping("/items/{itemId}")
+    public ApiResponse<ItemResponseDto.AvatarStoreBodyListDto> itemInfo(@PathVariable Long itemId, @RequestParam("itemPart")String itemPart) {
+        ItemResponseDto.AvatarStoreBodyListDto itemDto = itemService.makeAvatarStoreBodyPage(itemId, itemPart);
+        return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), itemDto);
     }
 }

--- a/src/main/java/com/brandol/converter/ItemConverter.java
+++ b/src/main/java/com/brandol/converter/ItemConverter.java
@@ -1,9 +1,14 @@
 package com.brandol.converter;
 import com.brandol.domain.mapping.MyItem;
+import com.brandol.dto.response.ItemResponseDto;
 import com.brandol.dto.response.MyItemResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import com.brandol.domain.Items;
+
+import java.util.List;
 
 @Slf4j
 @Component
@@ -23,6 +28,26 @@ public class ItemConverter {
                 .brandName(myItem.getItems().getBrand().getName())
                 .price(myItem.getItems().getPrice())
                 .createdAt(myItem.getCreatedAt())
+                .build();
+    }
+
+    public static ItemResponseDto.AvatarStoreBodyDto toItemResDTO(Items item) {
+
+        return ItemResponseDto.AvatarStoreBodyDto.builder()
+                .itemId(item.getId())
+                .itemsName(item.getName())
+                .itemDescription(item.getDescription())
+                .itemImage(item.getImage())
+                .itemPart(item.getItemPart().toString())
+                .itemPrice(item.getPrice())
+                .brandName(item.getBrand().getName())
+                .build();
+    }
+
+    public static ItemResponseDto.AvatarStoreBodyListDto toAvatarStoreBodyAllDto(
+            List<ItemResponseDto.AvatarStoreBodyDto> AvatarStoreBodyDtoList){
+        return ItemResponseDto.AvatarStoreBodyListDto.builder()
+                .AvatarStoreBodyDto(AvatarStoreBodyDtoList)
                 .build();
     }
 }

--- a/src/main/java/com/brandol/dto/response/ItemResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/ItemResponseDto.java
@@ -1,0 +1,31 @@
+package com.brandol.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+public class ItemResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AvatarStoreBodyListDto {
+        private List<ItemResponseDto.AvatarStoreBodyDto> AvatarStoreBodyDto;
+
+    }
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AvatarStoreBodyDto {
+        private Long itemId;
+        private String itemsName;
+        private String itemPart;
+        private String brandName;
+        private String itemImage;
+        private String itemDescription;
+        private int itemPrice;
+
+    }
+}

--- a/src/main/java/com/brandol/repository/ItemsRepository.java
+++ b/src/main/java/com/brandol/repository/ItemsRepository.java
@@ -18,5 +18,8 @@ public interface ItemsRepository extends JpaRepository<Items, Long> {
     @Query(value = "SELECT * FROM Items i WHERE i.item_part like :itemPart ORDER BY RAND() ",nativeQuery = true)
     List<Items> finditemPartByRandom(@Param("itemPart") String itemPart);
 
+    @Query(value = "SELECT * FROM Items i  ORDER BY CASE WHEN i.items_id = :itemId THEN 0 ELSE 1 END, RAND()",nativeQuery = true)
+    List<Items> finditemByIdandRandom(@Param("itemId") Long itemId);
+
 
 }

--- a/src/main/java/com/brandol/service/ItemService.java
+++ b/src/main/java/com/brandol/service/ItemService.java
@@ -4,10 +4,13 @@ import com.brandol.apiPayload.code.status.ErrorStatus;
 import com.brandol.apiPayload.exception.ErrorHandler;
 import com.brandol.aws.AmazonS3Manager;
 import com.brandol.converter.ItemConverter;
+import com.brandol.domain.Items;
 import com.brandol.domain.Member;
 import com.brandol.domain.mapping.MyItem;
 import com.brandol.dto.request.MyItemRequestDto;
+import com.brandol.dto.response.ItemResponseDto;
 import com.brandol.dto.response.MyItemResponseDto;
+import com.brandol.repository.ItemsRepository;
 import com.brandol.repository.MemberRepository;
 import com.brandol.repository.MyItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,11 +27,13 @@ import java.util.stream.Collectors;
 public class ItemService {
 
     private final MyItemRepository myItemRepository;
-    private final MemberRepository memberRepository;
-    private final AmazonS3Manager s3Manager;
-
+    private final ItemsRepository itemsRepository;
     public List<MyItemResponseDto.MyItemDto> getMyItemList(Long memberId) {
+        //Member member = memberRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus._NOT_EXIST_MEMBER));
         List<MyItem> myItemList = myItemRepository.findALlByMemberId(memberId);
+        /*if (myItemList.isEmpty()) {
+            throw new ErrorHandler();
+        }*/
         List<MyItemResponseDto.MyItemDto> myItemDtoList = new ArrayList<>();
 
         for (MyItem myItem : myItemList) {
@@ -48,25 +53,50 @@ public class ItemService {
         currentMyItemList.stream()
                 .filter(currentMyItem -> !wearingMyItemList.contains(currentMyItem))// 현재 착용중인 아이템이 wearingMyItemList에 없으면
                 .forEach(currentMyItem -> currentMyItem.updateIsWearing(false)); // isWearing은 false
-        wearingMyItemList.forEach(myItem -> {myItem.updateIsWearing(true);});
 
-        if (request.getAvatarImage() != null && !request.getAvatarImage().isEmpty()) {
-            // 기존 아바타 파일 S3에서 삭제
-            Member member = memberRepository.findById(memberId).orElseThrow(() -> new ErrorHandler(ErrorStatus._NOT_EXIST_MEMBER));
-            String existingMemberAvatar = member.getAvatar();
-            if (existingMemberAvatar != null && !existingMemberAvatar.isEmpty()) {
-                String existingAvatarFileName = s3Manager.getAvatarKeyName(existingMemberAvatar);
-                s3Manager.deleteFile(existingAvatarFileName);
+        wearingMyItemList.forEach(myItem -> {myItem.updateIsWearing(true);});
+        return "아이템 착용 성공";
+    }
+
+
+    public ItemResponseDto.AvatarStoreBodyListDto makeAvatarStoreBodyPage(Long itemId, String itemPart){
+
+
+
+
+
+        if(itemPart.equals("전체")){
+            // 전체 아바타 스토어 리스트
+            List<Items> total_item_List = itemsRepository.finditemByIdandRandom(itemId);
+
+            List<ItemResponseDto.AvatarStoreBodyDto> AvatarStore_Body_Total_DtoList = new ArrayList<>();
+            for(int i=0; i< total_item_List.size();i++){
+                ItemResponseDto.AvatarStoreBodyDto dto = ItemConverter.toItemResDTO(total_item_List.get(i));
+                AvatarStore_Body_Total_DtoList.add(dto);
             }
-            // 새로운 아바타 파일 업로드
-            String avatar = request.getAvatarImage().getOriginalFilename();
-            String avatarUUID = s3Manager.generateAvatarKeyName(avatar);
-            String avatarURL = s3Manager.uploadFile(avatarUUID, request.getAvatarImage());
-            // 해당 회원의 아바타 수정
-            member.updateAvatar(avatarURL);
-            return "아바타 저장 완료";
-        } else {
-            throw new ErrorHandler(ErrorStatus._FILE_AVATAR_INVALID);
+
+            return ItemConverter.toAvatarStoreBodyAllDto(AvatarStore_Body_Total_DtoList);
         }
+
+
+
+
+
+
+
+        // 종류별 아바타 스토어 리스트
+        List<Items> itempart_item_List = itemsRepository.finditemPartByRandom(itemPart);
+
+
+        List<ItemResponseDto.AvatarStoreBodyDto> AvatarStore_Body_DtoList = new ArrayList<>();
+        for(int i=0; i< itempart_item_List.size();i++){
+            ItemResponseDto.AvatarStoreBodyDto dto = ItemConverter.toItemResDTO(itempart_item_List.get(i));
+            AvatarStore_Body_DtoList.add(dto);
+        }
+
+
+        return ItemConverter.toAvatarStoreBodyAllDto(AvatarStore_Body_DtoList);
+
+
     }
 }


### PR DESCRIPTION
검색 페이지에서 특정 아이템 클릭 시, 아이템id와 아이템 종류를 리퀘스트로 받아, 피그마 기준 5페이지 d의 최상단에 해당 아이템 정보 조회
itemId =1, itemPart = 전체 -> 해당 아이템 최상단 노출
![111](https://github.com/yongiCorp/Server/assets/103201205/918a8ee2-0e4a-431f-bc9d-dbaf050d8f5e)

itemId =1, itemPart = 전체 이외의 나머지 -> 랜덤 노출
![222](https://github.com/yongiCorp/Server/assets/103201205/a6e9c9a2-3b87-44bd-b2ef-ad8fdab153a5)
