### PR TITLE
Refactor/97 @RequestParam memberId -> 인증객체 id 추출 방식 변경

### DIFF
--- a/src/main/java/com/brandol/controller/BrandController.java
+++ b/src/main/java/com/brandol/controller/BrandController.java
@@ -66,14 +66,16 @@ public class BrandController {
 
     @Operation(summary = "멤버 작성 글 조회",description ="2페이지 d 진입시 호출하는 API" )
     @GetMapping("/brands/{brandId}/my-written/articles")
-    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenArticle(@PathVariable("brandId")Long brandId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenArticle(@PathVariable("brandId")Long brandId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         MemberResponseDto.MemberWrittenMainDto dto = memberService.makeBrandMemberWrittenPage(memberId,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
     }
 
     @Operation(summary = "멤버 작성 댓글 조회",description ="2페이지 d 진입시 호출하는 API" )
     @GetMapping("/brands/{brandId}/my-written/comments")
-    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenComment(@PathVariable("brandId")Long brandId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<MemberResponseDto.MemberWrittenMainDto> memberWrittenComment(@PathVariable("brandId")Long brandId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         MemberResponseDto.MemberWrittenMainDto dto = memberService.makeBrandMemberWrittenCommentPage(memberId,brandId);
         return ApiResponse.onSuccess(SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), dto);
     }
@@ -83,9 +85,9 @@ public class BrandController {
     @PostMapping(value = "/brands/{brandId}/community/new",consumes = "multipart/form-data")
     public ApiResponse<String> crateBrandCommunity(@ModelAttribute BrandRequestDto.addCommunity communityDto,
                                                    @PathVariable("brandId")Long brandId,
-                                                   @RequestParam("memberId") Long memberID
+                                                   Authentication authentication
                                                    ){
-        Long memberId = memberID;
+        Long memberId = Long.parseLong(authentication.getName());
         Long communityId = brandService.createCommunity(communityDto,brandId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"article-id: "+communityId);
     }

--- a/src/main/java/com/brandol/controller/CommentController.java
+++ b/src/main/java/com/brandol/controller/CommentController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.method.P;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,97 +23,97 @@ public class CommentController {
     private final CommentService commentService;
 
     @Operation(summary = "팬덤 댓글 작성",description ="멤버가 팬덤 게시판 게시글에 댓글을 생성" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/fandom/{fandom_id}/comments/new")
-    public ApiResponse<String> addNewFandomComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("fandom_id")Long fandomId, @RequestParam("memberId")Long memberId){
+    public ApiResponse<String> addNewFandomComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("fandom_id")Long fandomId, Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long commentId = commentService.createFandomComment(dto,fandomId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"FandomCommentId: "+ commentId);
     }
 
     @Operation(summary = "팬덤 댓글 좋아요",description ="팬덤 게시판 댓글 좋어요 등록" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/fandom/comments/{commentId}/like")
-    public ApiResponse<String> fandomCommentLike(@PathVariable("commentId")Long commentId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> fandomCommentLike(@PathVariable("commentId")Long commentId, Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long fandomCommentLikeId = commentService.fandomCommentLike(commentId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(), "FandomCommentLikeId: "+fandomCommentLikeId);
     }
 
     @Operation(summary = "팬덤 댓글 좋아요 취소",description ="팬덤 게시판 댓글 좋어요 취소" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/fandom/comments/{commentId}/like-cancel")
-    public ApiResponse<String> fandomCommentLikeCancel(@PathVariable("commentId")Long commentId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> fandomCommentLikeCancel(@PathVariable("commentId")Long commentId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long fandomCommentLikeId = commentService.fandomCommentLikeCancel(commentId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(), "FandomCommentLikeId: "+fandomCommentLikeId);
     }
 
     @Operation(summary = "콘텐츠 댓글 작성",description ="멤버가 콘텐츠 게시판 게시글에 댓글을 생성" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/contents/{contents_id}/comments/new")
-    public ApiResponse<String> addNewContentsComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("contents_id")Long contentsId, @RequestParam("memberId")Long memberId){
+    public ApiResponse<String> addNewContentsComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("contents_id")Long contentsId, Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long commentId = commentService.crateContentsComment(dto,contentsId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"ContentsCommentId: "+ commentId);
     }
 
     @Operation(summary = "콘텐츠 댓글 좋아요",description ="콘텐츠 게시판 댓글 좋어요 등록" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/contents/comments/{commentId}/like")
-    public ApiResponse<String> contentsCommentLike(@PathVariable("commentId")Long commentId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> contentsCommentLike(@PathVariable("commentId")Long commentId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long contentsCommentLikeId = commentService.contentsCommentLike(commentId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(), "ContentsCommentLikeId: "+contentsCommentLikeId);
     }
 
     @Operation(summary = "콘텐츠 댓글 좋아요 취소",description ="콘텐츠 게시판 댓글 좋어요 취소" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/contents/comments/{commentId}/like-cancel")
-    public ApiResponse<String> contentsCommentLikeCancel(@PathVariable("commentId")Long commentId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> contentsCommentLikeCancel(@PathVariable("commentId")Long commentId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long contentsCommentLikeId = commentService.contentsCommentLikeCancel(commentId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(), "ContentsCommentLikeId: "+contentsCommentLikeId);
     }
 
     @Operation(summary = "커뮤니티 댓글 작성",description ="멤버가 커뮤니티 게시판 게시글에 댓글을 생성" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/communities/{community_id}/comments/new")
-    public ApiResponse<String> addNewCommunityComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("community_id")Long communityId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> addNewCommunityComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("community_id")Long communityId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long commentId = commentService.createCommunityComment(dto,communityId,memberId);
         return  ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"CommunityCommentId: "+ commentId);
     }
 
     @Operation(summary = "커뮤니티 댓글 좋아요",description ="커뮤니티 게시판 댓글 좋어요 등록" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/community/comments/{commentId}/like")
-    public ApiResponse<String> communityCommentLike(@PathVariable("commentId")Long commentId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> communityCommentLike(@PathVariable("commentId")Long commentId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long communityCommentLikeId = commentService.communityCommentLike(commentId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(), "CommunityCommentLikeId: "+communityCommentLikeId);
     }
 
     @Operation(summary = "커뮤니티 댓글 좋아요 취소",description ="커뮤니티 게시판 댓글 좋어요 취소" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/community/comments/{commentId}/like-cancel")
-    public ApiResponse<String> communityCommentLikeCancel(@PathVariable("commentId")Long commentId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> communityCommentLikeCancel(@PathVariable("commentId")Long commentId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long contentsLikeId = commentService.communityCommentLikeCancel(commentId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(), "CommunityCommentLikeId: "+contentsLikeId);
     }
 
     @Operation(summary = "팬덤 대댓글 작성",description ="멤버가 팬덤 게시판 게시글에 대댓글을 생성" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/fandom/{fandom_id}/comments/{commentId}")
-    public ApiResponse<String> addNewFandomNestedComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("fandom_id")Long fandomId, @RequestParam("memberId")Long memberId,@RequestParam("commentId")Long commentId){
+    public ApiResponse<String> addNewFandomNestedComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("fandom_id")Long fandomId,@RequestParam("commentId")Long commentId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long  nestedCommentId = commentService.createFandomNestedComment(dto,fandomId,commentId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"FandomCommentId: "+ nestedCommentId);
     }
 
     @Operation(summary = "콘텐츠 대댓글 작성",description ="멤버가 콘텐츠 게시판 게시글에 대댓글을 생성" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/contents/{contents_id}/comments/{commentId}")
-    public ApiResponse<String> addNewContentsNestedComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("contents_id")Long contentsId, @RequestParam("memberId")Long memberId,@RequestParam("commentId")Long commentId){
+    public ApiResponse<String> addNewContentsNestedComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("contents_id")Long contentsId,@RequestParam("commentId")Long commentId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long  nestedCommentId = commentService.createContentsNestedComment(dto,contentsId,commentId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"ContentsCommentId: "+ nestedCommentId);
     }
 
     @Operation(summary = "커뮤니티 대댓글 작성",description ="멤버가 커뮤니티 게시판 게시글에 대댓글을 생성" )
-    @Parameter(name = "memberId",description = "[임시]유저를 구분하는 유저 ID로 이후 로그인 서비스 도입시 토큰 대체")
     @PostMapping("/communities/{community_id}/comments/{commentId}")
-    public ApiResponse<String> addNewCommunityNestedComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("community_id")Long communityId, @RequestParam("memberId")Long memberId,@RequestParam("commentId")Long commentId){
+    public ApiResponse<String> addNewCommunityNestedComment(@RequestBody CommentRequestDto.addComment dto, @PathVariable("community_id")Long communityId,@RequestParam("commentId")Long commentId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long  nestedCommentId = commentService.createCommunityNestedComment(dto,communityId,commentId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(),SuccessStatus._CREATED.getMessage(),"CommunityCommentId: "+ nestedCommentId);
     }

--- a/src/main/java/com/brandol/controller/CommunityController.java
+++ b/src/main/java/com/brandol/controller/CommunityController.java
@@ -9,6 +9,7 @@ import com.brandol.service.CommunityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,14 +47,16 @@ public class CommunityController {
 
     @Operation(summary = "커뮤니티 게시글 좋아요 등록",description ="커뮤니티 게시글 좋아요 등록")
     @GetMapping("/brands/community/{communityId}/like")
-    public ApiResponse<String> FandomLike(@PathVariable("communityId")Long contentsId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> FandomLike(@PathVariable("communityId")Long contentsId, Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long communityLikesId = communityService.communityLike(contentsId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(),"CommunityLikesId: "+communityLikesId);
     }
 
     @Operation(summary = "커뮤니티 게시글 좋아요 취소",description ="커뮤니티 게시글 좋아요 취소")
     @GetMapping("/brands/community/{communityId}/like-cancel")
-    public ApiResponse<String> FandomLikeCancel(@PathVariable("communityId")Long communityId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> FandomLikeCancel(@PathVariable("communityId")Long communityId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long communityLikesId = communityService.communityLikeCancel(communityId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(),"CommunityLikesId: "+communityLikesId);
     }

--- a/src/main/java/com/brandol/controller/ContentsController.java
+++ b/src/main/java/com/brandol/controller/ContentsController.java
@@ -8,6 +8,7 @@ import com.brandol.service.ContentsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -52,14 +53,16 @@ public class ContentsController {
 
     @Operation(summary = "콘텐츠 게시글 좋아요 등록",description ="콘텐츠 게시글 좋아요 등록")
     @GetMapping("/brands/contents/{contentsId}/like")
-    public ApiResponse<String> FandomLike(@PathVariable("contentsId")Long contentsId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> FandomLike(@PathVariable("contentsId")Long contentsId, Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long contentsLikesId = contentsService.contentsLike(contentsId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(),"ContentsLikesId: "+contentsLikesId);
     }
 
     @Operation(summary = "콘텐츠 게시글 좋아요 취소",description ="콘텐츠 게시글 좋아요 취소")
     @GetMapping("/brands/contents/{contentsId}/like-cancel")
-    public ApiResponse<String> FandomLikeCancel(@PathVariable("contentsId")Long contentsId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> FandomLikeCancel(@PathVariable("contentsId")Long contentsId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long contentsLikesId = contentsService.contentsLikeCancel(contentsId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(),"ContentsLikesId: "+contentsLikesId);
     }

--- a/src/main/java/com/brandol/controller/FandomController.java
+++ b/src/main/java/com/brandol/controller/FandomController.java
@@ -7,6 +7,7 @@ import com.brandol.service.FandomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,14 +46,16 @@ public class FandomController {
 
     @Operation(summary = "팬덤 게시글 좋아요 등록",description ="팬덤 게시글 좋아요 등록")
     @GetMapping("/brands/fandoms/{fandomId}/like")
-    public ApiResponse<String> FandomLike(@PathVariable("fandomId")Long fandomId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> FandomLike(@PathVariable("fandomId")Long fandomId, Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long fandomLikesId = fandomService.fandomLike(fandomId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(),"FandomLikesId: "+fandomLikesId);
     }
 
     @Operation(summary = "팬덤 게시글 좋아요 취소",description ="팬덤 게시글 좋아요 취소")
     @GetMapping("/brands/fandoms/{fandomId}/like-cancel")
-    public ApiResponse<String> FandomLikeCancel(@PathVariable("fandomId")Long fandomId,@RequestParam("memberId")Long memberId){
+    public ApiResponse<String> FandomLikeCancel(@PathVariable("fandomId")Long fandomId,Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
         Long fandomLikesId = fandomService.fandomLikeCancel(fandomId,memberId);
         return ApiResponse.onSuccess(SuccessStatus._CREATED.getCode(), SuccessStatus._CREATED.getMessage(),"FandomLikesId: "+fandomLikesId);
     }


### PR DESCRIPTION
그동안 api 개발과정에서 테스트 편의를 위해 사용하던 @RequestParam memberId 를 제가 작성한 코드에 한정해서 모두   authentication.getName() 으로 변경 하였습니다.
+
인증 객체에서 memberId를 추출하는 과정 보단 바로 member Entity를 꺼내는것이 효율적이지만, 대다수의 repository에서 memberId를 필요로 하기 떄문에 Authentication 객체에서 멤버 아이디를 추출 하도록 수정 하였습니다.

또한 그동안 제가 제작한 모든 API에 대하여 Authentication을 적용하여 전체 테스트를 진행하였고, 이에 테스트중 발견한 문제점은 없었습니다. 

배포 직전 자리를 비워 죄송하단 말씀 드리고 싶습니다. 빠르게 재충전 하고 돌아오겠습니다!