### PR TITLE
♻️ [Refactor] 아바타 보유아이템 조회 시, 착용 전 아이템 이미지와 착용 아이템 이미지 조회

### DIFF
--- a/src/main/java/com/brandol/controller/AuthController.java
+++ b/src/main/java/com/brandol/controller/AuthController.java
@@ -65,7 +65,7 @@ public class AuthController {
     }
 
     @Operation(summary = "마이페이지 회원 정보 조회", description = "마이페이지 회원 정보(아바타, 닉네임, 포인트) 조회")
-    @PatchMapping("/info")
+    @GetMapping("/info")
     public ApiResponse<AuthResponseDto.MemberInfo> getMyPageInfo(Authentication authentication) {
         Long memberId = Long.parseLong(authentication.getName());
         AuthResponseDto.MemberInfo memberInfo = authService.getMemberInfo(memberId);

--- a/src/main/java/com/brandol/controller/ItemController.java
+++ b/src/main/java/com/brandol/controller/ItemController.java
@@ -27,7 +27,7 @@ public class ItemController {
     private final ItemService itemService;
     private final AvatarService avatarService;
 
-    @Operation(summary = "구매 아이템 조회",description = "내가 구매한 아이템, 아이템의 상세 정보, 아이템의 착용여부 조회")
+    @Operation(summary = "아바타 구매 아이템 조회",description = "내가 구매한 아이템, 아이템의 상세 정보, 아이템의 착용여부를 조회합니다. 응답의 image: 착용 전 아이템(보유아이템 목록) 이미지, wearingImage: 아바타 착용 아이템 이미지")
     @GetMapping("/myitems")
     public ApiResponse<List<MyItemResponseDto.MyItemDto>> getMyItems(Authentication authentication) {
         Long memberId = Long.parseLong(authentication.getName());

--- a/src/main/java/com/brandol/converter/AvatarConverter.java
+++ b/src/main/java/com/brandol/converter/AvatarConverter.java
@@ -27,6 +27,7 @@ public class AvatarConverter {
                 .part(myItem.getItems().getItemPart().toString())
                 .description(myItem.getItems().getDescription())
                 .image(myItem.getItems().getImage())
+                .wearingImage(myItem.getItems().getWearingImage())
                 .brandId(myItem.getItems().getBrand().getId())
                 .brandName(myItem.getItems().getBrand().getName())
                 .price(myItem.getItems().getPrice())

--- a/src/main/java/com/brandol/domain/Items.java
+++ b/src/main/java/com/brandol/domain/Items.java
@@ -27,7 +27,10 @@ public class Items extends BaseEntity {
     private String description;
 
     @Column(columnDefinition = "TEXT")
-    private String image;
+    private String image; // 착용 전 보유 이미지
+
+    @Column(columnDefinition = "TEXT")
+    private String wearingImage; // 아바타에 직접 착용되는 이미지
 
     @Column(nullable = false)
     private int price;

--- a/src/main/java/com/brandol/dto/response/MyItemResponseDto.java
+++ b/src/main/java/com/brandol/dto/response/MyItemResponseDto.java
@@ -10,15 +10,16 @@ public class MyItemResponseDto {
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class MyItemDto {
-        private Long myItemId; // 불필요하면 삭제 예정
+        private Long myItemId;
         private Long itemId;
         private Long brandId;
         private String brandName;
         private String itemName;
         private boolean isWearing;
-        private String part; // enum
+        private String part;
         private String description;
         private String image;
+        private String wearingImage;
         private int price;
         private LocalDateTime createdAt;
     }


### PR DESCRIPTION
close #104 

- 현재 Item 엔티티의 image 필드의 사용을 착용 전 아이템 이미지 저장하는 필드로 변경 
- Item 엔티티 에 **착용 후 이미지 필드(wearingImage)** 추가
- 착용 전 구매목록에 있을 때의 이미지 S3에 업로드
- 기존의 image필드는 아바타 보유 아이템 목록, 아바타 스토어, 타 사용자 착용 아이템 조회 등 에서 사용
- 새로 추가한 wearingImage 에  아바타에 직접 착용되는 이미지 저장 
- 착용 전 아이템과 착용 아이템 이미지가 같은 경우 > 두 필드에 같은 이미지 저장
- 착용 전 아이템과 착용 아이템 이미지가 다른 경우 (ex-skin) > 두 필드에 각각 다른 이미지 저장