### PR TITLE
회원가입 시 성별에 따라 아바타 기본 아이템 장착

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,6 @@ logging.level:
   org.hibernate.type : trace
 jwt:
   secret: ${JWT_SECRET}
+defaultItemIds:
+  male: ${DEFAULT_ITEM_MALE}
+  female: ${DEFAULT_ITEM_FEMALE}


### PR DESCRIPTION
close #123
아바타룸에서는 착용중인 아이템으로 아바타를 띄우는 방식으로 진행하기 때문에
회원가입 때 성별에 따라 기본 아이템을 장착(MyItem isWearing : true 로 저장) 합니다

application.yml에

defaultItemIds:
  male: ${DEFAULT_ITEM_MALE}
  female: ${DEFAULT_ITEM_FEMALE}
  
으로 여자 남자 기본 item의 id 리스트를 환경변수로 넣어줍니다. 

**❓ 기본 item들을 서버 DB에 넣고 위의 환경변수 값들을 알려드리고자 했으나, 기본 item들의 brand_id를 넣는 부분에서 난항을 겪고 카톡을 남겨놨습니다 ,, 확인 부탁드립니다!!**

**📌로컬에서는 저장되어있는 brand의 brand_id를 넣어서 테스트 했었습니다.** 