### PR TITLE
서브배너 탐색 범위 조정 기존:최신 컨텐츠(전체범위)10건 -> 변경:최신 컨텐츠(컨텐츠 중 이벤트에서만)10건 

### DIFF
--- a/src/main/java/com/brandol/repository/ContentsRepository.java
+++ b/src/main/java/com/brandol/repository/ContentsRepository.java
@@ -13,6 +13,9 @@ public interface ContentsRepository extends JpaRepository<Contents,Long> {
     @Query(value = "select * from contents c order by created_at desc LIMIT :cnt ",nativeQuery = true)
     List<Contents> findRecentBrands(@Param("cnt") int cnt);
 
+    @Query(value = "select c from Contents c where c.contentsType =com.brandol.domain.enums.ContentsType.EVENTS order by c.createdAt desc")
+    List<Contents>findRecentBrandEventsForSubBanner(Pageable pageable);
+
     @Query(value = "select  c from  Contents c where c.brand.id= :brandId and c.contentsType =com.brandol.domain.enums.ContentsType.EVENTS order by c.createdAt desc ")
     List<Contents>findRecentEvents(@Param("brandId")Long brandId, Pageable pageable);
 

--- a/src/main/java/com/brandol/service/MemberService.java
+++ b/src/main/java/com/brandol/service/MemberService.java
@@ -9,6 +9,7 @@ import com.brandol.domain.mapping.*;
 import com.brandol.dto.response.MemberResponseDto;
 import com.brandol.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,7 +74,7 @@ public class MemberService {
         brandList.add(0,brandol);
 
         //서브배너에 들어갈 콘텐츠 리스트
-        List<Contents> contentsList = contentsRepository.findRecentBrands(10);
+        List<Contents> contentsList = contentsRepository.findRecentBrandEventsForSubBanner(PageRequest.of(0,10));
 
         //브랜드리스트에 들어갈 멤버-브랜드-리스트 타입의 리스트
         List<MemberBrandList> memberBrandLists = memberBrandRepository.findAllSubscribedByMemberId(memberId);


### PR DESCRIPTION
컨텐츠 중에서 최신 브랜드-이벤트만 가져오는 Repository 메서드로 서브배너 담당 메서드 변경 -->
서브배너 탐색 범위 조정 기존:최신 컨텐츠(전체범위)10건 -> 변경:최신 컨텐츠(컨텐츠 중 이벤트에서만)10건 으로 변경